### PR TITLE
fix: base duplicate detection on the dedup key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.db
 *.csv
 !src/**/__fixtures__/*.csv
+!src/**/__fixtures__/**/*.csv

--- a/docs/database.md
+++ b/docs/database.md
@@ -51,7 +51,7 @@ CREATE TABLE transactions (
   note               TEXT,                   -- raw Communications field from CSV
   source_file        TEXT,                   -- original CSV filename
   imported_at        TEXT NOT NULL,          -- ISO 8601 timestamp of import
-  UNIQUE(date, amount, counterparty)         -- dedup key
+  UNIQUE(date, amount, counterparty)         -- duplicate detection key
 );
 ```
 
@@ -102,9 +102,13 @@ db.prepare(`
 // UPDATE transactions SET category_id = ai_category_id WHERE …
 ```
 
-### Dedup Strategy
+### Duplicate Detection Strategy
 
 The `UNIQUE(date, amount, counterparty)` constraint prevents duplicate imports. Use `INSERT OR IGNORE` so re-importing a CSV is always safe:
+
+- Current dedup identity is the business key `(date, amount, counterparty)`
+- `source_ref` is stored when available but is not currently part of duplicate detection
+- `source_file` and `imported_at` are audit metadata only and never affect deduplication
 
 ```ts
 db.prepare(`

--- a/src/commands/import/index.test.ts
+++ b/src/commands/import/index.test.ts
@@ -1,22 +1,21 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
 import { Database } from 'bun:sqlite'
+import { resolve } from 'node:path'
 import { seedCategories } from '@/db/categories/seed'
 import { initDb } from '@/db/schema'
-import { insertTransaction } from '@/db/transactions/mutations'
 import { getTransactions } from '@/db/transactions/queries'
-import { parseCsv } from '@/parsers/csv'
-import { findCsvFiles } from '.'
+import { findCsvFiles, insertAllTransactions, parseAllFiles } from '.'
 
-const FIXTURE = `${import.meta.dir}/../../parsers/__fixtures__/minimal.csv`
-const FIXTURES_DIR = `${import.meta.dir}/../../parsers/__fixtures__`
+const FIXTURE = resolve(`${import.meta.dir}/../../parsers/__fixtures__/minimal.csv`)
+const FIXTURES_DIR = resolve(`${import.meta.dir}/../../parsers/__fixtures__`)
+const IMPORT_FIXTURES_DIR = resolve(`${FIXTURES_DIR}/import`)
+const BASELINE_FIXTURE = resolve(`${IMPORT_FIXTURES_DIR}/baseline.csv`)
+const OVERLAP_FIXTURE = resolve(`${IMPORT_FIXTURES_DIR}/overlap.csv`)
+const MIXED_FIXTURE = resolve(`${IMPORT_FIXTURES_DIR}/mixed.csv`)
 
-async function importAll(db: Database, sourceFile: string): Promise<{ imported: number; errors: number }> {
-  const content = await Bun.file(sourceFile).text()
-  const { transactions, errors } = parseCsv(content, sourceFile)
-  for (const transaction of transactions) {
-    insertTransaction(db, transaction)
-  }
-  return { imported: transactions.length, errors: errors.length }
+async function importFiles(db: Database, files: string[]) {
+  const parsed = await parseAllFiles(files)
+  return insertAllTransactions(db, parsed)
 }
 
 describe('import pipeline', () => {
@@ -29,13 +28,14 @@ describe('import pipeline', () => {
   })
 
   it('imports 5 transactions from fixture', async () => {
-    const { imported } = await importAll(db, FIXTURE)
-    expect(imported).toBe(5)
+    const result = await importFiles(db, [FIXTURE])
+    expect(result.totalImported).toBe(5)
+    expect(result.totalDuplicatesSkipped).toBe(0)
     expect(getTransactions(db)).toHaveLength(5)
   })
 
   it('sets correct date format (yyyy-MM-dd)', async () => {
-    await importAll(db, FIXTURE)
+    await importFiles(db, [FIXTURE])
     const transactions = getTransactions(db)
     for (const transaction of transactions) {
       expect(transaction.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
@@ -43,26 +43,58 @@ describe('import pipeline', () => {
   })
 
   it('sets source_file on imported rows', async () => {
-    await importAll(db, FIXTURE)
+    await importFiles(db, [FIXTURE])
     const transactions = getTransactions(db)
     for (const transaction of transactions) {
       expect(transaction.sourceFile).toBe(FIXTURE)
     }
   })
 
-  it('imports valid rows and reports invalid rows without throwing', () => {
-    const content = `date,amount,counterparty
-2026-01-15,-42.50,ACME Shop
-not-a-date,-10.00,Bad Row
-2026-01-16,25.00,Salary`
-    const { transactions, errors } = parseCsv(content)
-    for (const transaction of transactions) {
-      insertTransaction(db, transaction)
-    }
-    expect(getTransactions(db)).toHaveLength(2)
-    expect(errors).toHaveLength(1)
-    expect(errors[0].row).toBe(3)
-    expect(errors[0].message).toContain('date must be YYYY-MM-DD')
+  it('re-imports the same full fixture without inserting duplicates', async () => {
+    const firstImport = await importFiles(db, [BASELINE_FIXTURE])
+    const secondImport = await importFiles(db, [BASELINE_FIXTURE])
+
+    expect(firstImport.totalImported).toBe(8)
+    expect(firstImport.totalDuplicatesSkipped).toBe(0)
+    expect(secondImport.totalImported).toBe(0)
+    expect(secondImport.totalDuplicatesSkipped).toBe(8)
+    expect(getTransactions(db)).toHaveLength(8)
+  })
+
+  it('imports overlapping full fixtures and keeps only unique rows', async () => {
+    const result = await importFiles(db, [BASELINE_FIXTURE, OVERLAP_FIXTURE])
+
+    expect(result.totalParsed).toBe(14)
+    expect(result.totalImported).toBe(11)
+    expect(result.totalDuplicatesSkipped).toBe(3)
+    expect(result.allErrors).toHaveLength(0)
+    expect(getTransactions(db)).toHaveLength(11)
+  })
+
+  it('imports valid rows and reports duplicate and invalid rows from a full scenario fixture', async () => {
+    await importFiles(db, [BASELINE_FIXTURE])
+
+    const result = await importFiles(db, [MIXED_FIXTURE])
+
+    expect(result.totalParsed).toBe(4)
+    expect(result.totalImported).toBe(2)
+    expect(result.totalDuplicatesSkipped).toBe(2)
+    expect(result.allErrors).toHaveLength(3)
+    expect(result.allErrors.map(error => error.row)).toEqual([5, 6, 7])
+    expect(getTransactions(db)).toHaveLength(10)
+  })
+
+  it('imports a directory of full-scenario fixtures as one batch', async () => {
+    const files = await findCsvFiles(IMPORT_FIXTURES_DIR)
+
+    const result = await importFiles(db, files)
+
+    expect(files).toEqual([BASELINE_FIXTURE, MIXED_FIXTURE, OVERLAP_FIXTURE])
+    expect(result.totalParsed).toBe(18)
+    expect(result.totalImported).toBe(13)
+    expect(result.totalDuplicatesSkipped).toBe(5)
+    expect(result.allErrors).toHaveLength(3)
+    expect(getTransactions(db)).toHaveLength(13)
   })
 })
 
@@ -78,6 +110,17 @@ describe('findCsvFiles', () => {
   it('includes the fixture file', async () => {
     const files = await findCsvFiles(FIXTURES_DIR)
     expect(files.some(f => f.endsWith('minimal.csv'))).toBe(true)
+  })
+
+  it('returns absolute file paths when given a relative directory path', async () => {
+    const relativeFixturesDir = IMPORT_FIXTURES_DIR.replace(`${process.cwd()}/`, '')
+
+    const files = await findCsvFiles(relativeFixturesDir)
+
+    expect(files).toEqual([BASELINE_FIXTURE, MIXED_FIXTURE, OVERLAP_FIXTURE])
+    for (const file of files) {
+      expect(file).toBe(resolve(file))
+    }
   })
 
   it('returns empty array for an empty directory', async () => {

--- a/src/commands/import/index.ts
+++ b/src/commands/import/index.ts
@@ -8,32 +8,37 @@ import { insertTransaction } from '@/db/transactions/mutations'
 import { parseCsv, type ParseError } from '@/parsers/csv'
 import { resolveDbPath } from '@/config'
 
-type ParsedFile = {
+export type ParsedFile = {
   file: string
   transactions: ReturnType<typeof parseCsv>['transactions']
   errors: ParseError[]
 }
 
-type InsertResult = {
+export type InsertResult = {
+  totalParsed: number
   totalImported: number
+  totalDuplicatesSkipped: number
   allErrors: Array<ParseError & { file: string }>
 }
 
 export async function findCsvFiles(dirPath: string): Promise<string[]> {
-  const entries = await readdir(dirPath, { withFileTypes: true })
+  const absoluteDirPath = resolve(dirPath)
+  const entries = await readdir(absoluteDirPath, { withFileTypes: true })
   return entries
     .filter(entry => entry.isFile() && extname(entry.name).toLowerCase() === '.csv')
-    .map(entry => join(dirPath, entry.name))
+    .map(entry => join(absoluteDirPath, entry.name))
+    .sort((leftPath, rightPath) => leftPath.localeCompare(rightPath))
 }
 
-async function resolveCsvFiles(path: string): Promise<string[] | null> {
-  const info = await stat(path).catch(() => null)
-  if (!info) return null
-  if (info.isDirectory()) return findCsvFiles(path)
-  return [resolve(path)]
+async function resolveCsvFiles(path: string): Promise<string[] | undefined> {
+  const absolutePath = resolve(path)
+  const info = await stat(absolutePath).catch(() => undefined)
+  if (!info) return undefined
+  if (info.isDirectory()) return findCsvFiles(absolutePath)
+  return [absolutePath]
 }
 
-async function parseAllFiles(files: string[]): Promise<ParsedFile[]> {
+export async function parseAllFiles(files: string[]): Promise<ParsedFile[]> {
   const label = files.length === 1 ? `Reading ${basename(files[0])}` : `Reading ${files.length} files`
   const fileSpinner = spinner()
   fileSpinner.start(label)
@@ -50,21 +55,25 @@ async function parseAllFiles(files: string[]): Promise<ParsedFile[]> {
   return parsed
 }
 
-async function insertAllTransactions(db: Database, parsed: ParsedFile[]): Promise<InsertResult> {
+export async function insertAllTransactions(db: Database, parsed: ParsedFile[]): Promise<InsertResult> {
   const totalRows = parsed.reduce((sum, { transactions }) => sum + transactions.length, 0)
   const insertProgress = progress({ max: Math.max(1, totalRows), style: 'heavy' })
   insertProgress.start(`0 / ${totalRows}`)
   let totalImported = 0
+  let totalDuplicatesSkipped = 0
   const allErrors: Array<ParseError & { file: string }> = []
   try {
     for (const { file, transactions, errors } of parsed) {
+      let importedFromFile = 0
       db.transaction(() => {
         for (const transaction of transactions) {
-          insertTransaction(db, transaction)
+          importedFromFile += insertTransaction(db, transaction)
         }
       })()
-      totalImported += transactions.length
-      insertProgress.advance(transactions.length, `${basename(file)} — ${totalImported} / ${totalRows}`)
+      const duplicatesFromFile = transactions.length - importedFromFile
+      totalImported += importedFromFile
+      totalDuplicatesSkipped += duplicatesFromFile
+      insertProgress.advance(transactions.length, `${basename(file)} — ${totalImported} imported / ${totalRows} parsed`)
       await Bun.sleep(0)
       allErrors.push(...errors.map(parseError => ({ ...parseError, file })))
     }
@@ -72,16 +81,18 @@ async function insertAllTransactions(db: Database, parsed: ParsedFile[]): Promis
     insertProgress.error('Failed')
     throw error
   }
-  insertProgress.stop(`${totalImported} / ${totalRows}`)
-  return { totalImported, allErrors }
+  insertProgress.stop(`${totalImported} imported / ${totalRows} parsed`)
+  return { totalParsed: totalRows, totalImported, totalDuplicatesSkipped, allErrors }
 }
 
-function reportResults(totalImported: number, allErrors: Array<ParseError & { file: string }>): void {
+function reportResults(result: InsertResult): void {
+  const { totalImported, totalDuplicatesSkipped, allErrors } = result
   for (const { file, row, message } of allErrors) {
     log.warn(`${file} line ${row}: ${message}`)
   }
   const errorSuffix = allErrors.length > 0 ? `, ${allErrors.length} invalid row(s) skipped` : ''
-  outro(`✓ ${totalImported} imported${errorSuffix}`)
+  const duplicateSuffix = totalDuplicatesSkipped > 0 ? `, ${totalDuplicatesSkipped} duplicate row(s) skipped` : ''
+  outro(`✓ ${totalImported} imported${duplicateSuffix}${errorSuffix}`)
 }
 
 async function importAction(path: string, options: { db: string }): Promise<void> {
@@ -115,10 +126,10 @@ async function importAction(path: string, options: { db: string }): Promise<void
 
   try {
     const parsed = await parseAllFiles(files)
-    const { totalImported, allErrors } = await insertAllTransactions(database, parsed)
+    const result = await insertAllTransactions(database, parsed)
     process.removeListener('SIGINT', onCancel)
     database.close()
-    reportResults(totalImported, allErrors)
+    reportResults(result)
   } catch (error) {
     process.removeListener('SIGINT', onCancel)
     log.error(error instanceof Error ? error.message : String(error))

--- a/src/db/transactions/README.md
+++ b/src/db/transactions/README.md
@@ -4,10 +4,20 @@ Stores imported bank transactions plus manual and AI categorization state.
 
 ## Columns
 
-- `date`, `amount`, `counterparty`: core transaction fields and dedup key
+- `date`, `amount`, `counterparty`: core transaction fields and the current duplicate detection key
+- `source_ref`: source-system reference kept as metadata only; it does not participate in the duplicate detection key
 - `category_id`: user-confirmed category
 - `ai_category_id`, `ai_confidence`, `ai_reasoning`: AI suggestion data
 - `source_file`, `imported_at`: import audit metadata
+
+## Duplicate Detection Rule
+
+Duplicate imports are currently identified by the business key `(date, amount, counterparty)`.
+
+This means:
+
+- changing `source_file`, `imported_at`, or `source_ref` does not make a row unique
+- changing any of `date`, `amount`, or `counterparty` does make it a separate row
 
 ## Queries
 

--- a/src/db/transactions/mutations.test.ts
+++ b/src/db/transactions/mutations.test.ts
@@ -29,6 +29,42 @@ describe('insertTransaction', () => {
     const changes = insertTransaction(db, fakeTransaction)
     expect(changes).toBe(1)
   })
+
+  it('returns 0 when inserting a duplicate transaction', () => {
+    insertTransaction(db, fakeTransaction)
+
+    const changes = insertTransaction(db, fakeTransaction)
+
+    expect(changes).toBe(0)
+    expect(getTransactions(db)).toHaveLength(1)
+  })
+
+  it('treats source_ref as metadata and not part of the duplicate detection key', () => {
+    insertTransaction(db, {
+      ...fakeTransaction,
+      sourceRef: '001:1001',
+    })
+
+    const changes = insertTransaction(db, {
+      ...fakeTransaction,
+      sourceRef: '001:1002',
+    })
+
+    expect(changes).toBe(0)
+    expect(getTransactions(db)).toHaveLength(1)
+  })
+
+  it('inserts a second row when the duplicate detection key changes', () => {
+    insertTransaction(db, fakeTransaction)
+
+    const changes = insertTransaction(db, {
+      ...fakeTransaction,
+      amount: -40.5,
+    })
+
+    expect(changes).toBe(1)
+    expect(getTransactions(db)).toHaveLength(2)
+  })
 })
 
 describe('updateCategory', () => {

--- a/src/db/transactions/mutations.ts
+++ b/src/db/transactions/mutations.ts
@@ -3,7 +3,7 @@ import type { Transaction } from '@/types'
 
 export function insertTransaction(db: Database, transaction: Omit<Transaction, 'id'>): number {
   const statement = db.prepare(`
-    INSERT INTO transactions
+    INSERT OR IGNORE INTO transactions
       (date, amount, counterparty, counterparty_iban, currency, account, source_ref,
        category_id, ai_category_id, ai_confidence, ai_reasoning, note, source_file, imported_at)
     VALUES

--- a/src/db/transactions/schema.test.ts
+++ b/src/db/transactions/schema.test.ts
@@ -3,6 +3,13 @@ import { Database } from 'bun:sqlite'
 import { createCategoriesTable } from '@/db/categories/schema'
 import { createTransactionsTable } from './schema'
 
+function insertRawTransaction(db: Database, values: { date: string; amount: number; counterparty: string }): void {
+  db.prepare(`
+    INSERT INTO transactions (date, amount, counterparty, currency, imported_at)
+    VALUES (?, ?, ?, 'EUR', '2026-02-01T10:00:00.000Z')
+  `).run(values.date, values.amount, values.counterparty)
+}
+
 describe('createTransactionsTable', () => {
   it('creates transactions table', () => {
     const db = new Database(':memory:')
@@ -23,6 +30,32 @@ describe('createTransactionsTable', () => {
     expect(() => {
       createTransactionsTable(db)
       createTransactionsTable(db)
+    }).not.toThrow()
+  })
+
+  it('enforces uniqueness on date amount and counterparty', () => {
+    const db = new Database(':memory:')
+    createCategoriesTable(db)
+    createTransactionsTable(db)
+
+    insertRawTransaction(db, { date: '2026-02-01', amount: -18.45, counterparty: 'City Market' })
+
+    expect(() => {
+      insertRawTransaction(db, { date: '2026-02-01', amount: -18.45, counterparty: 'City Market' })
+    }).toThrow(/UNIQUE constraint failed/)
+  })
+
+  it('allows rows when one part of the duplicate detection key differs', () => {
+    const db = new Database(':memory:')
+    createCategoriesTable(db)
+    createTransactionsTable(db)
+
+    insertRawTransaction(db, { date: '2026-02-01', amount: -18.45, counterparty: 'City Market' })
+
+    expect(() => {
+      insertRawTransaction(db, { date: '2026-02-02', amount: -18.45, counterparty: 'City Market' })
+      insertRawTransaction(db, { date: '2026-02-01', amount: -18.46, counterparty: 'City Market' })
+      insertRawTransaction(db, { date: '2026-02-01', amount: -18.45, counterparty: 'City Market Annex' })
     }).not.toThrow()
   })
 })

--- a/src/db/transactions/schema.ts
+++ b/src/db/transactions/schema.ts
@@ -1,6 +1,10 @@
 import { Database } from 'bun:sqlite'
 
+export const TRANSACTION_DUPLICATE_DETECTION_KEY_COLUMNS = ['date', 'amount', 'counterparty'] as const
+
 export function createTransactionsTable(db: Database): void {
+  const duplicateDetectionKeySql = TRANSACTION_DUPLICATE_DETECTION_KEY_COLUMNS.join(', ')
+
   db.run(`
     CREATE TABLE IF NOT EXISTS transactions (
       id                 INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -17,7 +21,8 @@ export function createTransactionsTable(db: Database): void {
       ai_reasoning       TEXT,
       note               TEXT,
       source_file        TEXT,
-      imported_at        TEXT NOT NULL
+      imported_at        TEXT NOT NULL,
+      UNIQUE(${duplicateDetectionKeySql})
     )
   `)
 }

--- a/src/parsers/__fixtures__/import/baseline.csv
+++ b/src/parsers/__fixtures__/import/baseline.csv
@@ -1,0 +1,9 @@
+date,amount,counterparty,counterparty_iban,currency,account,note
+2026-02-01,-3.20,Metro Kiosk,,EUR,BE11 1111 1111 1111,Morning coffee
+2026-02-01,-18.45,City Market,,EUR,BE11 1111 1111 1111,Groceries basket
+2026-02-02,-42.00,Northwind Energy,BE00 0000 0000 1001,EUR,BE11 1111 1111 1111,Monthly electricity
+2026-02-03,2450.00,Example Payroll,,EUR,BE11 1111 1111 1111,February salary
+2026-02-03,-12.80,Metro Kiosk,,EUR,BE11 1111 1111 1111,Evening snacks
+2026-02-04,-55.10,Test Pharmacy,BE00 0000 0000 1002,EUR,,Prescription refill
+2026-02-05,-8.90,Blue Bottle Laundry,,EUR,BE11 1111 1111 1111,Laundry card topup
+2026-02-05,-74.00,ACME Telecom,BE00 0000 0000 1003,EUR,BE11 1111 1111 1111,Fiber subscription

--- a/src/parsers/__fixtures__/import/mixed.csv
+++ b/src/parsers/__fixtures__/import/mixed.csv
@@ -1,0 +1,8 @@
+date,amount,counterparty,counterparty_iban,currency,account,note
+2026-02-01,-18.45,City Market,,EUR,BE11 1111 1111 1111,Groceries basket repeat
+2026-02-08,-14.20,Studio Bakery,,EUR,BE11 1111 1111 1111,Weekend brunch
+2026-02-08,-14.20,Studio Bakery,,EUR,BE11 1111 1111 1111,Weekend brunch duplicate
+not-a-date,-11.00,Bad Date Merchant,,EUR,BE11 1111 1111 1111,Bad row
+2026-02-09,invalid,Amount Problem,,EUR,BE11 1111 1111 1111,Bad amount
+2026-02-10,-9.50,,,EUR,BE11 1111 1111 1111,
+2026-02-11,89.00,Refund Hub,,EUR,BE11 1111 1111 1111,Returned purchase

--- a/src/parsers/__fixtures__/import/overlap.csv
+++ b/src/parsers/__fixtures__/import/overlap.csv
@@ -1,0 +1,7 @@
+date,amount,counterparty,counterparty_iban,currency,account,note
+2026-02-01,-3.20,Metro Kiosk,,EUR,BE11 1111 1111 1111,Morning coffee replay
+2026-02-03,2450.00,Example Payroll,,EUR,BE11 1111 1111 1111,Salary replay
+2026-02-05,-74.00,ACME Telecom,BE00 0000 0000 1003,EUR,BE11 1111 1111 1111,Fiber replay
+2026-02-06,-24.50,Corner Books,,EUR,BE11 1111 1111 1111,Two paperbacks
+2026-02-06,-6.70,Metro Kiosk,,EUR,BE11 1111 1111 1111,Lunch sandwich
+2026-02-07,-31.00,Green Fuel,BE00 0000 0000 1004,EUR,BE11 1111 1111 1111,City fuel stop


### PR DESCRIPTION
## Summary
- enforce duplicate detection using the current dedup key `(date, amount, counterparty)`
- use `INSERT OR IGNORE` during import so re-imports and overlapping files skip duplicates instead of failing
- document that `source_ref`, `source_file`, and `imported_at` are metadata and do not affect duplicate detection
- add fixture-based coverage for duplicate, overlapping, and invalid import scenarios
- normalize discovered import file paths to absolute paths for consistent source file tracking

## Why
This change is about duplicate detection based on the dedup key. The effective identity of an imported transaction is the business key `(date, amount, counterparty)`, not transport or audit metadata. A different `source_ref`, `source_file`, or import timestamp should not create a second row when the dedup key is unchanged.

## Testing
- bun test
- bun test src/db/transactions/schema.test.ts src/db/transactions/mutations.test.ts