### PR TITLE
fix: use Promise.resolve in categorize mock to fix typecheck

### DIFF
--- a/src/ai/categorize.test.ts
+++ b/src/ai/categorize.test.ts
@@ -2,7 +2,7 @@ import { mock, beforeEach, describe, expect, it } from 'bun:test'
 import type { Transaction, Category } from '@/types'
 import { TransactionCategorizationResultSchema } from '@/ai/schemas'
 
-const generateObjectMock = mock(() => ({
+const generateObjectMock = mock(() => Promise.resolve({
   object: {
     categoryId: '3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e7f',
     confidence: 0.8,


### PR DESCRIPTION
The generateObjectMock was declared as a synchronous function, causing
TypeScript to infer mockResolvedValue/mockRejectedValue parameter types
as never. Wrapping the return value in Promise.resolve() makes the mock
properly typed as async without triggering the require-await lint rule.

https://claude.ai/code/session_01SvCBW9PwnMLnpMfMmEDD3a