### PR TITLE
chore: format changelog after release-please creates or updates a PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,38 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      pr: ${{ steps.release.outputs.pr }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           release-type: node
+
+  format-changelog:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.pr != '' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Format changelog
+        run: bun run format
+
+      - name: Commit formatted changelog
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --staged --quiet || git commit -m "chore: format changelog"
+          git push


### PR DESCRIPTION
## Summary

- Adds a `format-changelog` job to the Release Please workflow
- After release-please creates or updates a release PR, the job checks out the PR branch, runs `bun run format`, and commits any changes back
- Ensures `CHANGELOG.md` is always Prettier-formatted so the format check CI passes on release PRs

## Test plan

- [ ] Merge into main and verify the next release-please PR has a Prettier-formatted `CHANGELOG.md`
- [ ] Confirm the format check job passes on the release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)