### PR TITLE
docs(ai): add README for the ai module directory

### DIFF
--- a/src/ai/README.md
+++ b/src/ai/README.md
@@ -13,7 +13,7 @@ AI integration layer — model access, prompt building, and transaction categori
 
 ## Fast-path vs LLM
 
-`categorizeTransaction` checks `transaction_category_suggestions` first. If a counterparty has ≥ 3 approved suggestions all pointing to the same category (`MIN_FAST_PATH_APPROVALS`), that category is returned immediately with `confidence: 1.0` and no API call is made.
+When a `db` is provided, `categorizeTransaction` checks `transaction_category_suggestions` first. If a counterparty has ≥ 3 suggestions with status `approved` or `applied` all pointing to the same category (`MIN_FAST_PATH_APPROVALS`), that category is returned immediately with `confidence: 1.0` and no API call is made; otherwise, it falls back to the LLM.
 
 ## Configuration
 

--- a/src/ai/README.md
+++ b/src/ai/README.md
@@ -1,0 +1,29 @@
+# src/ai
+
+AI integration layer — model access, prompt building, and transaction categorization.
+
+## Modules
+
+| File | Responsibility |
+| --- | --- |
+| `client.ts` | Creates the AI model instance via `@ai-sdk/openai`; reads token and base URL from config or env vars |
+| `prompts.ts` | Builds the categorization prompt from a transaction, category list, and optional past examples |
+| `schemas.ts` | Zod schema and type for the structured LLM output (`categorySlug`, `confidence`, `reasoning`) |
+| `categorize.ts` | Orchestrates categorization: fast-path (counterparty consensus) then LLM fallback |
+
+## Fast-path vs LLM
+
+`categorizeTransaction` checks `transaction_category_suggestions` first. If a counterparty has ≥ 3 approved suggestions all pointing to the same category (`MIN_FAST_PATH_APPROVALS`), that category is returned immediately with `confidence: 1.0` and no API call is made.
+
+## Configuration
+
+| Source | Keys |
+| --- | --- |
+| `Bun.env` | `GITHUB_TOKEN`, `AI_MODEL`, `AI_BASE_URL` |
+| `flouz config` | `githubToken`, `aiModel`, `aiBaseUrl` |
+
+Env vars take precedence over stored config. Default model: `openai/gpt-4o-mini` via `https://models.github.ai/inference`.
+
+## Provider contract
+
+`getModel()` returns a Vercel AI SDK–compatible chat model. Swapping the provider (e.g. `@ai-sdk/anthropic`) requires changes only in `client.ts`.

--- a/src/ai/README.md
+++ b/src/ai/README.md
@@ -4,12 +4,12 @@ AI integration layer — model access, prompt building, and transaction categori
 
 ## Modules
 
-| File | Responsibility |
-| --- | --- |
-| `client.ts` | Creates the AI model instance via `@ai-sdk/openai`; reads token and base URL from config or env vars |
-| `prompts.ts` | Builds the categorization prompt from a transaction, category list, and optional past examples |
-| `schemas.ts` | Zod schema and type for the structured LLM output (`categorySlug`, `confidence`, `reasoning`) |
-| `categorize.ts` | Orchestrates categorization: fast-path (counterparty consensus) then LLM fallback |
+| File            | Responsibility                                                                                       |
+| --------------- | ---------------------------------------------------------------------------------------------------- |
+| `client.ts`     | Creates the AI model instance via `@ai-sdk/openai`; reads token and base URL from config or env vars |
+| `prompts.ts`    | Builds the categorization prompt from a transaction, category list, and optional past examples       |
+| `schemas.ts`    | Zod schema and type for the structured LLM output (`categorySlug`, `confidence`, `reasoning`)        |
+| `categorize.ts` | Orchestrates categorization: fast-path (counterparty consensus) then LLM fallback                    |
 
 ## Fast-path vs LLM
 
@@ -17,10 +17,10 @@ AI integration layer — model access, prompt building, and transaction categori
 
 ## Configuration
 
-| Source | Keys |
-| --- | --- |
-| `Bun.env` | `GITHUB_TOKEN`, `AI_MODEL`, `AI_BASE_URL` |
-| `flouz config` | `githubToken`, `aiModel`, `aiBaseUrl` |
+| Source         | Keys                                      |
+| -------------- | ----------------------------------------- |
+| `Bun.env`      | `GITHUB_TOKEN`, `AI_MODEL`, `AI_BASE_URL` |
+| `flouz config` | `githubToken`, `aiModel`, `aiBaseUrl`     |
 
 Env vars take precedence over stored config. Default model: `openai/gpt-4o-mini` via `https://models.github.ai/inference`.
 


### PR DESCRIPTION
## Summary

- Adds `src/ai/README.md` documenting the four modules (`client.ts`, `prompts.ts`, `schemas.ts`, `categorize.ts`)
- Explains the fast-path vs LLM categorization flow and the `MIN_FAST_PATH_APPROVALS` threshold
- Documents configuration sources (env vars vs stored config) and the provider-swap contract

## Test plan

- [ ] README renders correctly on GitHub
- [ ] No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)