### PR TITLE
refactor(transactions): rename note to bank_communication

### DIFF
--- a/src/ai/prompts.ts
+++ b/src/ai/prompts.ts
@@ -10,8 +10,8 @@ function formatTransactionDetails(transaction: Transaction): string {
     `Amount: ${transaction.amount} ${transaction.currency}`,
     `Counterparty: ${transaction.counterparty}`,
   ]
-  if (transaction.note) {
-    lines.push(`Note: ${transaction.note}`)
+  if (transaction.bankCommunication) {
+    lines.push(`Bank communication: ${transaction.bankCommunication}`)
   }
   return lines.join('\n')
 }

--- a/src/commands/transactions/format.ts
+++ b/src/commands/transactions/format.ts
@@ -4,7 +4,7 @@ export interface ListRow {
   date: string
   amount: string
   counterparty: string
-  note: string
+  bankCommunication: string
   category: string
 }
 
@@ -17,14 +17,14 @@ export function formatTransactionTable(rows: ListRow[]): string[] {
       { header: 'Note', width: 30, minWidth: 14, wrapWord: true },
       { header: 'Category', width: 18, minWidth: 10, wrapWord: true },
     ],
-    rows: rows.map((row) => [row.date, row.amount, row.counterparty, row.note, row.category]),
+    rows: rows.map((row) => [row.date, row.amount, row.counterparty, row.bankCommunication, row.category]),
   })
 }
 
 export function buildCsv(rows: ListRow[]): string {
-  const header = 'date,amount,counterparty,note,category'
+  const header = 'date,amount,counterparty,bank_communication,category'
   const dataRows = rows.map((row) =>
-    [row.date, row.amount, row.counterparty, row.note, row.category].map(escapeCsvField).join(','),
+    [row.date, row.amount, row.counterparty, row.bankCommunication, row.category].map(escapeCsvField).join(','),
   )
   return [header, ...dataRows].join('\n')
 }

--- a/src/commands/transactions/import.test.ts
+++ b/src/commands/transactions/import.test.ts
@@ -68,7 +68,7 @@ describe('import pipeline', () => {
           date: transaction.date,
           amount: transaction.amount,
           counterparty: transaction.counterparty,
-          note: transaction.note,
+          bankCommunication: transaction.bankCommunication,
         }),
       )
     }

--- a/src/commands/transactions/import.ts
+++ b/src/commands/transactions/import.ts
@@ -31,7 +31,7 @@ export function resolveImportedTransaction(db: Database, transaction: ImportedTr
     currency: transaction.currency,
     accountId,
     categoryId: transaction.categoryId,
-    note: transaction.note,
+    bankCommunication: transaction.bankCommunication,
     sourceFile: transaction.sourceFile,
     importedAt: transaction.importedAt,
   }

--- a/src/commands/transactions/list.test.ts
+++ b/src/commands/transactions/list.test.ts
@@ -49,7 +49,7 @@ describe('formatTransactionTable', () => {
         date: '2026-01-15',
         amount: '-42.50',
         counterparty: 'ACME Shop',
-        note: 'Invoice 42',
+        bankCommunication: 'Invoice 42',
         category: 'groceries',
       },
     ])
@@ -83,20 +83,20 @@ describe('parseOutputFormat', () => {
 })
 
 describe('buildCsv', () => {
-  it('serializes full counterparty and note fields', () => {
+  it('serializes full counterparty and original_name fields', () => {
     expect(
       buildCsv([
         {
           date: '2026-01-15',
           amount: '-42.50',
           counterparty: 'ACME Shop and Bakery',
-          note: 'Monthly, refill',
+          bankCommunication: 'Monthly, refill',
           category: 'groceries',
         },
       ]),
     ).toBe(
       [
-        'date,amount,counterparty,note,category',
+        'date,amount,counterparty,bank_communication,category',
         '2026-01-15,-42.50,ACME Shop and Bakery,"Monthly, refill",groceries',
       ].join('\n'),
     )
@@ -117,7 +117,7 @@ describe('buildJson', () => {
           date: '2026-01-15',
           amount: '-42.50',
           counterparty: 'ACME Shop and Bakery',
-          note: 'Invoice 42 paid in full',
+          bankCommunication: 'Invoice 42 paid in full',
           category: 'groceries',
         },
       ]),
@@ -128,7 +128,7 @@ describe('buildJson', () => {
         '    "date": "2026-01-15",',
         '    "amount": "-42.50",',
         '    "counterparty": "ACME Shop and Bakery",',
-        '    "note": "Invoice 42 paid in full",',
+        '    "bankCommunication": "Invoice 42 paid in full",',
         '    "category": "groceries"',
         '  }',
         ']',

--- a/src/commands/transactions/list.ts
+++ b/src/commands/transactions/list.ts
@@ -30,7 +30,7 @@ interface ListRow {
   date: string
   amount: string
   counterparty: string
-  note: string
+  bankCommunication: string
   category: string
 }
 
@@ -94,7 +94,7 @@ function toListRows(transactions: Transaction[], categorySlugById: Map<string, s
     date: transaction.date,
     amount: formatAmount(transaction.amount),
     counterparty: transaction.counterparty,
-    note: transaction.note ?? '',
+    bankCommunication: transaction.bankCommunication ?? '',
     category: resolveCategorySlug(transaction.categoryId, categorySlugById),
   }))
 }
@@ -116,10 +116,10 @@ export function formatTransactionTable(rows: ListRow[]): string[] {
         truncate: 12,
       },
       { header: 'Counterparty', width: 30, minWidth: 16, wrapWord: true },
-      { header: 'Note', width: 30, minWidth: 14, wrapWord: true },
+      { header: 'Bank Communication', width: 30, minWidth: 14, wrapWord: true },
       { header: 'Category', width: 18, minWidth: 10, wrapWord: true },
     ],
-    rows: rows.map((row) => [row.date, row.amount, row.counterparty, row.note, row.category]),
+    rows: rows.map((row) => [row.date, row.amount, row.counterparty, row.bankCommunication, row.category]),
   })
 }
 
@@ -134,9 +134,9 @@ export function parseOutputFormat(value: string): OutputFormat {
 }
 
 export function buildCsv(rows: ListRow[]): string {
-  const header = 'date,amount,counterparty,note,category'
+  const header = 'date,amount,counterparty,bank_communication,category'
   const dataRows = rows.map((row) =>
-    [row.date, row.amount, row.counterparty, row.note, row.category].map(escapeCsvField).join(','),
+    [row.date, row.amount, row.counterparty, row.bankCommunication, row.category].map(escapeCsvField).join(','),
   )
   return [header, ...dataRows].join('\n')
 }

--- a/src/db/transactions/hash.test.ts
+++ b/src/db/transactions/hash.test.ts
@@ -73,29 +73,29 @@ describe('computeTransactionHash', () => {
     expect(leftHash).not.toBe(rightHash)
   })
 
-  it('changes when note changes', () => {
+  it('changes when bankCommunication changes', () => {
     const leftHash = computeTransactionHash({
       date: '2026-01-15',
       amount: -42.5,
       counterparty: 'ACME Shop',
-      note: 'Invoice 42',
+      bankCommunication: 'Invoice 42',
     })
     const rightHash = computeTransactionHash({
       date: '2026-01-15',
       amount: -42.5,
       counterparty: 'ACME Shop',
-      note: 'Invoice 43',
+      bankCommunication: 'Invoice 43',
     })
 
     expect(leftHash).not.toBe(rightHash)
   })
 
-  it('changes when note is present versus absent', () => {
+  it('changes when bankCommunication is present versus absent', () => {
     const leftHash = computeTransactionHash({
       date: '2026-01-15',
       amount: -42.5,
       counterparty: 'ACME Shop',
-      note: 'Invoice 42',
+      bankCommunication: 'Invoice 42',
     })
     const rightHash = computeTransactionHash({
       date: '2026-01-15',

--- a/src/db/transactions/hash.ts
+++ b/src/db/transactions/hash.ts
@@ -1,11 +1,16 @@
 import type { Transaction } from '@/types'
 
-export type TransactionHashInput = Pick<Transaction, 'date' | 'amount' | 'counterparty' | 'note'>
+export type TransactionHashInput = Pick<Transaction, 'date' | 'amount' | 'counterparty' | 'bankCommunication'>
 
 export function computeTransactionHash(transaction: TransactionHashInput): string {
   const hasher = new Bun.CryptoHasher('sha256')
   hasher.update(
-    JSON.stringify([transaction.date, transaction.amount, transaction.counterparty, transaction.note ?? null]),
+    JSON.stringify([
+      transaction.date,
+      transaction.amount,
+      transaction.counterparty,
+      transaction.bankCommunication ?? null,
+    ]),
   )
   return hasher.digest('hex')
 }

--- a/src/db/transactions/mutations.ts
+++ b/src/db/transactions/mutations.ts
@@ -6,10 +6,10 @@ export function insertTransaction(db: Database, transaction: NewTransaction): nu
   const statement = db.prepare(`
     INSERT OR IGNORE INTO transactions
       (date, amount, counterparty, hash, counterparty_iban, currency, account_id,
-       category_id, note, source_file, imported_at)
+       category_id, bank_communication, source_file, imported_at)
     VALUES
       ($date, $amount, $counterparty, $hash, $counterpartyIban, $currency, $accountId,
-       $categoryId, $note, $sourceFile, $importedAt)
+       $categoryId, $bankCommunication, $sourceFile, $importedAt)
   `)
   const result = statement.run({
     $date: transaction.date,
@@ -20,7 +20,7 @@ export function insertTransaction(db: Database, transaction: NewTransaction): nu
     $currency: transaction.currency,
     $accountId: transaction.accountId ?? null,
     $categoryId: transaction.categoryId ?? null,
-    $note: transaction.note ?? null,
+    $bankCommunication: transaction.bankCommunication ?? null,
     $sourceFile: transaction.sourceFile ?? null,
     $importedAt: transaction.importedAt,
   })

--- a/src/db/transactions/queries.test.ts
+++ b/src/db/transactions/queries.test.ts
@@ -71,7 +71,7 @@ describe('getTransactions', () => {
         date: transaction.date,
         amount: transaction.amount,
         counterparty: transaction.counterparty,
-        note: transaction.note,
+        bankCommunication: transaction.bankCommunication,
       }),
     )
   })

--- a/src/db/transactions/queries.ts
+++ b/src/db/transactions/queries.ts
@@ -12,7 +12,7 @@ function rowToTransaction(row: Record<string, unknown>): Transaction {
     currency: row.currency as string,
     accountId: (row.account_id as number | null) ?? undefined,
     categoryId: (row.category_id as string | null) ?? undefined,
-    note: (row.note as string | null) ?? undefined,
+    bankCommunication: (row.bank_communication as string | null) ?? undefined,
     sourceFile: (row.source_file as string | null) ?? undefined,
     importedAt: row.imported_at as string,
   }

--- a/src/db/transactions/schema.ts
+++ b/src/db/transactions/schema.ts
@@ -14,7 +14,7 @@ export function createTransactionsTable(db: Database): void {
       currency           TEXT DEFAULT 'EUR',
       account_id         INTEGER REFERENCES accounts(id),
       category_id        TEXT REFERENCES categories(id),
-      note               TEXT,
+      bank_communication TEXT,
       source_file        TEXT,
       imported_at        TEXT NOT NULL
     )

--- a/src/parsers/csv.test.ts
+++ b/src/parsers/csv.test.ts
@@ -29,7 +29,7 @@ describe('parseCsv', () => {
       expect(first.counterpartyIban).toBe('BE00 0000 0000 0001')
       expect(first.currency).toBe('EUR')
       expect(first.accountKey).toBe('checking')
-      expect(first.note).toBe('Invoice 42')
+      expect(first.bankCommunication).toBe('Invoice 42')
     })
 
     it('defaults currency to EUR when column is empty', async () => {
@@ -44,7 +44,7 @@ describe('parseCsv', () => {
       const { transactions } = parseCsv(content)
       const noOptionals = transactions[1]
       expect(noOptionals.counterpartyIban).toBeUndefined()
-      expect(noOptionals.note).toBeUndefined()
+      expect(noOptionals.bankCommunication).toBeUndefined()
     })
 
     it('sets sourceFile on every transaction', async () => {
@@ -88,7 +88,7 @@ describe('parseCsv', () => {
         transactions: [tx],
       } = parseCsv(content)
       expect(tx.counterparty).toBe('PAIEMENT MAESTRO DELHAIZE')
-      expect(tx.note).toBe('PAIEMENT MAESTRO DELHAIZE')
+      expect(tx.bankCommunication).toBe('PAIEMENT MAESTRO DELHAIZE')
     })
 
     it('ignores blank lines between data rows', () => {

--- a/src/parsers/csv.ts
+++ b/src/parsers/csv.ts
@@ -56,7 +56,7 @@ function parseRow(row: RawRow, sourceFile?: string): ImportedTransaction {
     counterpartyIban: data.counterparty_iban || undefined,
     currency: data.currency,
     accountKey: data.account || undefined,
-    note: data.note || undefined,
+    bankCommunication: data.note || undefined,
     sourceFile,
     importedAt: new Date().toISOString(),
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface Transaction {
   currency: string // default 'EUR'
   accountId?: number
   categoryId?: string
-  note?: string
+  bankCommunication?: string
   sourceFile?: string
   importedAt: string // ISO timestamp
 }


### PR DESCRIPTION
## Summary

- Renames the `note` column in the `transactions` table to `bank_communication` to better reflect that the field holds the raw communication text from the bank's CSV export
- Updates the TypeScript property from `note` to `bankCommunication` across types, db layer, parser, commands, AI prompts, and all tests
- The CSV input column header (`note`) is unchanged — it maps to the bank's export format which we don't control

## Test plan

- [ ] All 345 existing tests pass (`bun test`)
- [ ] Run the SQL migration on an existing database: `sqlite3 ~/.config/flouz/flouz.db "ALTER TABLE transactions RENAME COLUMN note TO bank_communication;"`
- [ ] Import a CSV and verify the `bank_communication` field is populated correctly
- [ ] Run `flouz transactions list` and confirm the `Bank Communication` column renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)