### PR TITLE
feat(transactions): add user comment field

### DIFF
--- a/src/ai/prompts.test.ts
+++ b/src/ai/prompts.test.ts
@@ -51,6 +51,19 @@ describe('buildTransactionCategorizationPrompt', () => {
     })
   })
 
+  describe('with a user comment', () => {
+    it('includes the comment in the transaction section', () => {
+      const transactionWithComment: Transaction = { ...fakeTransaction, comment: 'weekly grocery run' }
+      const prompt = buildTransactionCategorizationPrompt(transactionWithComment, fakeCategories)
+      expect(prompt).toContain('User comment: weekly grocery run')
+    })
+
+    it('does not include a User comment line when comment is absent', () => {
+      const prompt = buildTransactionCategorizationPrompt(fakeTransaction, fakeCategories)
+      expect(prompt).not.toContain('User comment:')
+    })
+  })
+
   describe('reasoning instruction', () => {
     it('includes the reasoning instruction in the Instructions section', () => {
       const prompt = buildTransactionCategorizationPrompt(fakeTransaction, fakeCategories)

--- a/src/ai/prompts.ts
+++ b/src/ai/prompts.ts
@@ -13,6 +13,9 @@ function formatTransactionDetails(transaction: Transaction): string {
   if (transaction.bankCommunication) {
     lines.push(`Bank communication: ${transaction.bankCommunication}`)
   }
+  if (transaction.comment) {
+    lines.push(`User comment: ${transaction.comment}`)
+  }
   return lines.join('\n')
 }
 

--- a/src/db/transactions/mutations.test.ts
+++ b/src/db/transactions/mutations.test.ts
@@ -7,7 +7,7 @@ import { createCategoriesTable } from '@/db/categories/schema'
 import { seedCategories } from '@/db/categories/seed'
 import { getTransactions } from './queries'
 import { createTransactionsTable } from './schema'
-import { insertTransaction, updateCategory } from './mutations'
+import { insertTransaction, updateCategory, updateComment } from './mutations'
 
 const fakeTransaction: NewTransaction = {
   date: '2026-01-15',
@@ -49,5 +49,24 @@ describe('updateCategory', () => {
     updateCategory(db, transaction.id!, 'food-groceries')
     const [updatedTransaction] = getTransactions(db)
     expect(updatedTransaction.categoryId).toBe('food-groceries')
+  })
+})
+
+describe('updateComment', () => {
+  it('sets the comment on a transaction', () => {
+    insertTransaction(db, fakeTransaction)
+    const [transaction] = getTransactions(db)
+    updateComment(db, transaction.id!, 'groceries run before holiday')
+    const [updatedTransaction] = getTransactions(db)
+    expect(updatedTransaction.comment).toBe('groceries run before holiday')
+  })
+
+  it('clears the comment when passed undefined', () => {
+    insertTransaction(db, fakeTransaction)
+    const [transaction] = getTransactions(db)
+    updateComment(db, transaction.id!, 'some comment')
+    updateComment(db, transaction.id!, undefined)
+    const [updatedTransaction] = getTransactions(db)
+    expect(updatedTransaction.comment).toBeUndefined()
   })
 })

--- a/src/db/transactions/mutations.ts
+++ b/src/db/transactions/mutations.ts
@@ -32,6 +32,10 @@ export function updateCategory(db: Database, id: number, categoryId: string): vo
   db.prepare('UPDATE transactions SET category_id = ? WHERE id = ?').run(categoryId, id)
 }
 
+export function updateComment(db: Database, id: number, comment: string | undefined): void {
+  db.prepare('UPDATE transactions SET comment = ? WHERE id = ?').run(comment ?? null, id)
+}
+
 export function applyTransactionCategory(db: Database, id: number, categoryId: string): number {
   const result = db
     .prepare('UPDATE transactions SET category_id = ? WHERE id = ? AND category_id IS NULL')

--- a/src/db/transactions/queries.ts
+++ b/src/db/transactions/queries.ts
@@ -15,6 +15,7 @@ function rowToTransaction(row: Record<string, unknown>): Transaction {
     bankCommunication: (row.bank_communication as string | null) ?? undefined,
     sourceFile: (row.source_file as string | null) ?? undefined,
     importedAt: row.imported_at as string,
+    comment: (row.comment as string | null) ?? undefined,
   }
 }
 

--- a/src/db/transactions/schema.test.ts
+++ b/src/db/transactions/schema.test.ts
@@ -57,6 +57,16 @@ describe('createTransactionsTable', () => {
     expect(getColumnNames(db)).not.toContain('account')
   })
 
+  it('creates the comment column', () => {
+    const db = new Database(':memory:')
+    createCategoriesTable(db)
+    createAccountsTable(db)
+
+    createTransactionsTable(db)
+
+    expect(getColumnNames(db)).toContain('comment')
+  })
+
   it('creates the hash index', () => {
     const db = new Database(':memory:')
     createCategoriesTable(db)

--- a/src/db/transactions/schema.ts
+++ b/src/db/transactions/schema.ts
@@ -16,7 +16,8 @@ export function createTransactionsTable(db: Database): void {
       category_id        TEXT REFERENCES categories(id),
       bank_communication TEXT,
       source_file        TEXT,
-      imported_at        TEXT NOT NULL
+      imported_at        TEXT NOT NULL,
+      comment            TEXT
     )
   `)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,9 +29,10 @@ export interface Transaction {
   bankCommunication?: string
   sourceFile?: string
   importedAt: string // ISO timestamp
+  comment?: string
 }
 
-export type NewTransaction = Omit<Transaction, 'id' | 'hash'>
+export type NewTransaction = Omit<Transaction, 'id' | 'hash' | 'comment'>
 
 export type ImportedTransaction = Omit<NewTransaction, 'accountId'> & {
   accountKey?: string


### PR DESCRIPTION
## Summary

- Adds a nullable `comment TEXT` column to the `transactions` table for user-written annotations
- Excludes `comment` from `NewTransaction` (and therefore `ImportedTransaction`) so the import path can never set it — only `updateComment()` can write this field
- Surfaces the comment in the LLM categorization prompt as `User comment: …` when present

## Test plan

- [ ] `bun test src/db/transactions/schema.test.ts` — verifies `comment` column is created
- [ ] `bun test src/db/transactions/mutations.test.ts` — covers `updateComment` set and clear
- [ ] `bun test src/ai/prompts.test.ts` — covers comment appearing / not appearing in prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)