### PR TITLE
feat(transactions): add interactive comment command

### DIFF
--- a/src/commands/transactions/comment.test.ts
+++ b/src/commands/transactions/comment.test.ts
@@ -216,6 +216,19 @@ describe('comment action — invalid ID argument', () => {
 
     expect(outcome).toEqual({ status: 'rejected', errorCode: 1 })
   })
+
+  it('exits with code 1 when ID is partially numeric (e.g. "42abc")', async () => {
+    const { handle } = createInMemoryDatabase()
+    openDatabaseMock.mockReturnValue(handle)
+
+    const outcome = await collectCommandOutcome<CommentOutcome>(
+      () => runCommandSilently(createCommentCommand('default.db'), ['42abc']),
+      () => ({ status: 'resolved' }),
+      (errorCode) => ({ status: 'rejected', errorCode }),
+    )
+
+    expect(outcome).toEqual({ status: 'rejected', errorCode: 1 })
+  })
 })
 
 describe('comment action — skip', () => {

--- a/src/commands/transactions/comment.test.ts
+++ b/src/commands/transactions/comment.test.ts
@@ -204,6 +204,19 @@ describe('comment action — invalid ID argument', () => {
     expect(logErrorMock).toHaveBeenCalled()
   })
 
+  it('exits with code 1 when ID is a partial number like "42abc"', async () => {
+    const { handle } = createInMemoryDatabase()
+    openDatabaseMock.mockReturnValue(handle)
+
+    const outcome = await collectCommandOutcome<CommentOutcome>(
+      () => runCommandSilently(createCommentCommand('default.db'), ['42abc']),
+      () => ({ status: 'resolved' }),
+      (errorCode) => ({ status: 'rejected', errorCode }),
+    )
+
+    expect(outcome).toEqual({ status: 'rejected', errorCode: 1 })
+  })
+
   it('exits with code 1 when ID is zero', async () => {
     const { handle } = createInMemoryDatabase()
     openDatabaseMock.mockReturnValue(handle)

--- a/src/commands/transactions/comment.test.ts
+++ b/src/commands/transactions/comment.test.ts
@@ -1,0 +1,356 @@
+import { mock, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import type { Database } from 'bun:sqlite'
+import {
+  collectCommandOutcome,
+  createCommandTestDatabase,
+  createOpenDatabaseMock,
+  createProcessExitMock,
+  getArgumentSetup,
+  restoreProcessExit,
+  runCommandSilently,
+  setProcessExit,
+} from '@/commands/test-helpers'
+import { createAccountsTable } from '@/db/accounts/schema'
+import { createCategoriesTable } from '@/db/categories/schema'
+import { createTransactionsTable } from '@/db/transactions/schema'
+import { insertTransaction } from '@/db/transactions/mutations'
+import type { Command } from 'commander'
+
+const openDatabaseMock = createOpenDatabaseMock()
+
+void mock.module('@/db/schema', () => ({
+  openDatabase: (dbPath: string) => openDatabaseMock(dbPath),
+}))
+
+const selectResponseQueue: string[] = []
+const textResponseQueue: string[] = []
+
+const selectMock = mock(() => Promise.resolve(selectResponseQueue.shift() ?? 'quit'))
+const textMock = mock(() => Promise.resolve(textResponseQueue.shift() ?? ''))
+const introMock = mock((_message: string) => {})
+const outroMock = mock((_message: string) => {})
+const noteMock = mock((_message: string, _title?: string) => {})
+const cancelMock = mock((_message: string) => {})
+const logInfoMock = mock((_message: string) => {})
+const logErrorMock = mock((_message: string) => {})
+const logSuccessMock = mock((_message: string) => {})
+
+void mock.module('@clack/prompts', () => ({
+  intro: introMock,
+  outro: outroMock,
+  note: noteMock,
+  cancel: cancelMock,
+  isCancel: (_value: unknown) => false,
+  log: {
+    info: logInfoMock,
+    error: logErrorMock,
+    success: logSuccessMock,
+  },
+  select: selectMock,
+  text: textMock,
+}))
+
+const processExitMock = createProcessExitMock()
+let createCommentCommand: (defaultDb: string) => Command
+let originalProcessExit: typeof process.exit
+
+const baseTransaction = {
+  date: '2026-01-15',
+  amount: -42.5,
+  counterparty: 'ACME Shop',
+  currency: 'EUR',
+  importedAt: new Date().toISOString(),
+}
+
+function createInMemoryDatabase() {
+  return createCommandTestDatabase((database) => {
+    createCategoriesTable(database)
+    createAccountsTable(database)
+    createTransactionsTable(database)
+  })
+}
+
+function getLastId(database: Database): number {
+  const row = database.prepare('SELECT last_insert_rowid() AS id').get() as { id: number }
+  return row.id
+}
+
+function getComment(database: Database, id: number): string | null {
+  const row = database.prepare('SELECT comment FROM transactions WHERE id = ?').get(id) as {
+    comment: string | null
+  } | null
+  return row?.comment ?? null
+}
+
+async function runCommentCommand(database: Database, args: string[]): Promise<void> {
+  openDatabaseMock.mockReturnValue(database)
+  await runCommandSilently(createCommentCommand('default.db'), args)
+}
+
+type CommentOutcome = { status: 'resolved' } | { status: 'rejected'; errorCode: number | undefined }
+
+beforeAll(async () => {
+  originalProcessExit = process.exit
+  ;({ createCommentCommand } = await import('./comment'))
+})
+
+beforeEach(() => {
+  openDatabaseMock.mockReset()
+  selectMock.mockClear()
+  textMock.mockClear()
+  introMock.mockClear()
+  outroMock.mockClear()
+  noteMock.mockClear()
+  cancelMock.mockClear()
+  logInfoMock.mockClear()
+  logErrorMock.mockClear()
+  logSuccessMock.mockClear()
+  processExitMock.mockClear()
+  selectResponseQueue.length = 0
+  textResponseQueue.length = 0
+  originalProcessExit = setProcessExit(processExitMock)
+})
+
+afterEach(() => {
+  restoreProcessExit(originalProcessExit)
+})
+
+describe('createCommentCommand', () => {
+  it('creates the command with name "comment"', () => {
+    expect(createCommentCommand('flouz.db').name()).toBe('comment')
+  })
+
+  it('registers [id] as an optional non-variadic positional argument', () => {
+    const argument = getArgumentSetup(createCommentCommand('flouz.db'), 0)
+    expect(argument).toMatchObject({ name: 'id', required: false, variadic: false })
+  })
+
+  it('has --from option', () => {
+    const option = createCommentCommand('flouz.db').options.find((option) => option.long === '--from')
+    expect(option).toBeDefined()
+  })
+
+  it('has --to option', () => {
+    const option = createCommentCommand('flouz.db').options.find((option) => option.long === '--to')
+    expect(option).toBeDefined()
+  })
+
+  it('has --search option', () => {
+    const option = createCommentCommand('flouz.db').options.find((option) => option.long === '--search')
+    expect(option).toBeDefined()
+  })
+
+  it('has --limit option', () => {
+    const option = createCommentCommand('flouz.db').options.find((option) => option.long === '--limit')
+    expect(option).toBeDefined()
+  })
+
+  it('registers --db option with the supplied default path', () => {
+    const option = createCommentCommand('my.db').options.find((option) => option.long === '--db')
+    expect(option?.defaultValue).toBe('my.db')
+  })
+})
+
+describe('comment action — no transactions found', () => {
+  it('exits cleanly when no transactions match filters', async () => {
+    const { handle } = createInMemoryDatabase()
+    await runCommentCommand(handle, [])
+    expect(outroMock).toHaveBeenCalled()
+  })
+
+  it('logs an informational message when no transactions match filters', async () => {
+    const { handle } = createInMemoryDatabase()
+    await runCommentCommand(handle, [])
+    expect(logInfoMock).toHaveBeenCalled()
+  })
+
+  it('exits cleanly when the given ID does not exist', async () => {
+    const { handle } = createInMemoryDatabase()
+    await runCommentCommand(handle, ['999'])
+    expect(outroMock).toHaveBeenCalled()
+  })
+
+  it('logs an informational message when the given ID does not exist', async () => {
+    const { handle } = createInMemoryDatabase()
+    await runCommentCommand(handle, ['999'])
+    expect(logInfoMock).toHaveBeenCalled()
+  })
+})
+
+describe('comment action — invalid ID argument', () => {
+  it('exits with code 1 when ID is not a number', async () => {
+    const { handle } = createInMemoryDatabase()
+    openDatabaseMock.mockReturnValue(handle)
+
+    const outcome = await collectCommandOutcome<CommentOutcome>(
+      () => runCommandSilently(createCommentCommand('default.db'), ['abc']),
+      () => ({ status: 'resolved' }),
+      (errorCode) => ({ status: 'rejected', errorCode }),
+    )
+
+    expect(outcome).toEqual({ status: 'rejected', errorCode: 1 })
+  })
+
+  it('logs an error message when ID is not a number', async () => {
+    const { handle } = createInMemoryDatabase()
+    openDatabaseMock.mockReturnValue(handle)
+
+    await collectCommandOutcome(
+      () => runCommandSilently(createCommentCommand('default.db'), ['abc']),
+      () => undefined,
+      () => undefined,
+    )
+
+    expect(logErrorMock).toHaveBeenCalled()
+  })
+
+  it('exits with code 1 when ID is zero', async () => {
+    const { handle } = createInMemoryDatabase()
+    openDatabaseMock.mockReturnValue(handle)
+
+    const outcome = await collectCommandOutcome<CommentOutcome>(
+      () => runCommandSilently(createCommentCommand('default.db'), ['0']),
+      () => ({ status: 'resolved' }),
+      (errorCode) => ({ status: 'rejected', errorCode }),
+    )
+
+    expect(outcome).toEqual({ status: 'rejected', errorCode: 1 })
+  })
+})
+
+describe('comment action — skip', () => {
+  it('does not save a comment when skip is selected', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, baseTransaction)
+    const id = getLastId(database)
+    selectResponseQueue.push('skip')
+
+    await runCommentCommand(handle, [])
+
+    expect(getComment(database, id)).toBeNull()
+  })
+})
+
+describe('comment action — set', () => {
+  it('saves the comment when set is selected and text is entered', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, baseTransaction)
+    const id = getLastId(database)
+    selectResponseQueue.push('set')
+    textResponseQueue.push('Grocery run')
+
+    await runCommentCommand(handle, [])
+
+    expect(getComment(database, id)).toBe('Grocery run')
+  })
+
+  it('trims whitespace from the saved comment', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, baseTransaction)
+    const id = getLastId(database)
+    selectResponseQueue.push('set')
+    textResponseQueue.push('  Grocery run  ')
+
+    await runCommentCommand(handle, [])
+
+    expect(getComment(database, id)).toBe('Grocery run')
+  })
+
+  it('does not save when the entered comment is blank', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, baseTransaction)
+    const id = getLastId(database)
+    selectResponseQueue.push('set')
+    textResponseQueue.push('   ')
+
+    await runCommentCommand(handle, [])
+
+    expect(getComment(database, id)).toBeNull()
+  })
+})
+
+describe('comment action — clear', () => {
+  it('removes an existing comment when clear is selected', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, { ...baseTransaction, comment: 'Old note' } as typeof baseTransaction)
+    const id = getLastId(database)
+    database.prepare('UPDATE transactions SET comment = ? WHERE id = ?').run('Old note', id)
+    selectResponseQueue.push('clear')
+
+    await runCommentCommand(handle, [])
+
+    expect(getComment(database, id)).toBeNull()
+  })
+})
+
+describe('comment action — quit', () => {
+  it('stops processing remaining transactions when quit is selected', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, baseTransaction)
+    const id1 = getLastId(database)
+    insertTransaction(database, { ...baseTransaction, counterparty: 'Other Shop' })
+    const id2 = getLastId(database)
+    selectResponseQueue.push('quit')
+
+    await runCommentCommand(handle, [])
+
+    expect({ comment1: getComment(database, id1), comment2: getComment(database, id2) }).toEqual({
+      comment1: null,
+      comment2: null,
+    })
+  })
+})
+
+describe('comment action — direct ID', () => {
+  it('targets only the transaction with the given ID', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, baseTransaction)
+    const id1 = getLastId(database)
+    insertTransaction(database, { ...baseTransaction, counterparty: 'Other Shop' })
+    const id2 = getLastId(database)
+    selectResponseQueue.push('set')
+    textResponseQueue.push('Only this one')
+
+    await runCommentCommand(handle, [String(id1)])
+
+    expect({ comment1: getComment(database, id1), comment2: getComment(database, id2) }).toEqual({
+      comment1: 'Only this one',
+      comment2: null,
+    })
+  })
+})
+
+describe('comment action — filters', () => {
+  it('only processes transactions matching --search filter', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, baseTransaction)
+    const id1 = getLastId(database)
+    insertTransaction(database, { ...baseTransaction, counterparty: 'Other Shop' })
+    const id2 = getLastId(database)
+    selectResponseQueue.push('set')
+    textResponseQueue.push('Matched')
+
+    await runCommentCommand(handle, ['--search', 'ACME'])
+
+    expect({ comment1: getComment(database, id1), comment2: getComment(database, id2) }).toEqual({
+      comment1: 'Matched',
+      comment2: null,
+    })
+  })
+})
+
+describe('comment action — database error', () => {
+  it('exits with code 1 when openDatabase throws', async () => {
+    openDatabaseMock.mockImplementation(() => {
+      throw new Error('Cannot open DB')
+    })
+
+    const outcome = await collectCommandOutcome<CommentOutcome>(
+      () => runCommandSilently(createCommentCommand('default.db'), []),
+      () => ({ status: 'resolved' }),
+      (errorCode) => ({ status: 'rejected', errorCode }),
+    )
+
+    expect(outcome).toEqual({ status: 'rejected', errorCode: 1 })
+  })
+})

--- a/src/commands/transactions/comment.ts
+++ b/src/commands/transactions/comment.ts
@@ -127,6 +127,10 @@ async function annotateTransactions(db: Database, transactions: Transaction[]): 
   return summary
 }
 
+function isInvalidTransactionId(idArg: string, id: number): boolean {
+  return !/^\d+$/.test(idArg) || !Number.isSafeInteger(id) || id <= 0
+}
+
 function formatSummary(summary: CommentSummary, total: number): string {
   const acted = summary.updated + summary.cleared
   return `Reviewed ${acted + summary.skipped}/${total} — ${summary.updated} updated, ${summary.cleared} cleared, ${summary.skipped} skipped`
@@ -148,7 +152,7 @@ async function commentAction(idArg: string | undefined, options: CommentOptions)
     database = openDatabase(dbPath)
 
     const id = idArg !== undefined ? Number.parseInt(idArg, 10) : undefined
-    if (idArg !== undefined && (!/^\d+$/.test(idArg) || !Number.isSafeInteger(id!) || id! <= 0)) {
+    if (idArg !== undefined && isInvalidTransactionId(idArg, id!)) {
       process.removeListener('SIGINT', onCancel)
       database.close()
       log.error(`Invalid transaction ID: ${idArg}`)

--- a/src/commands/transactions/comment.ts
+++ b/src/commands/transactions/comment.ts
@@ -46,7 +46,7 @@ function loadTransactions(db: Database, id: number | undefined, options: Comment
 
 function formatTransactionNote(transaction: Transaction, index: number, total: number): string {
   const lines = [
-    `[${index}/${total}]  ${transaction.date}  ${formatAmount(transaction.amount)} EUR`,
+    `[${index}/${total}]  ${transaction.date}  ${formatAmount(transaction.amount)} ${transaction.currency}`,
     `Counterparty : ${transaction.counterparty}`,
   ]
   if (transaction.bankCommunication !== undefined) lines.push(`Bank note    : ${transaction.bankCommunication}`)
@@ -148,7 +148,7 @@ async function commentAction(idArg: string | undefined, options: CommentOptions)
     database = openDatabase(dbPath)
 
     const id = idArg !== undefined ? Number.parseInt(idArg, 10) : undefined
-    if (idArg !== undefined && (Number.isNaN(id!) || id! <= 0)) {
+    if (idArg !== undefined && (!/^\d+$/.test(idArg) || !Number.isSafeInteger(id!) || id! <= 0)) {
       process.removeListener('SIGINT', onCancel)
       database.close()
       log.error(`Invalid transaction ID: ${idArg}`)

--- a/src/commands/transactions/comment.ts
+++ b/src/commands/transactions/comment.ts
@@ -77,7 +77,7 @@ async function promptDecision(transaction: Transaction, index: number, total: nu
 }
 
 async function promptComment(current: string | undefined): Promise<string | symbol> {
-  return text({
+  return await text({
     message: 'Enter comment:',
     initialValue: current ?? '',
     placeholder: 'Leave blank to skip',
@@ -100,7 +100,7 @@ async function applyDecision(
   if (decision === 'set') {
     const input = await promptComment(transaction.comment)
     if (isCancel(input)) return 'quit'
-    const trimmed = (input as string).trim()
+    const trimmed = input.toString().trim()
     if (trimmed === '') return 'skip'
     updateComment(db, transaction.id, trimmed)
     log.success('Comment saved')

--- a/src/commands/transactions/comment.ts
+++ b/src/commands/transactions/comment.ts
@@ -1,0 +1,194 @@
+import { cancel, intro, isCancel, log, note, outro, select, text } from '@clack/prompts'
+import { type Database } from 'bun:sqlite'
+import { Command } from 'commander'
+import { resolve } from 'node:path'
+import { formatAmount } from '@/cli/format'
+import { openDatabase } from '@/db/schema'
+import { getTransactionById, getTransactions } from '@/db/transactions/queries'
+import { updateComment } from '@/db/transactions/mutations'
+import type { Transaction, TransactionFilters } from '@/types'
+import { toBaseFilters } from '@/commands/transactions/parse-options'
+
+interface CommentOptions {
+  from?: string
+  to?: string
+  search?: string
+  limit?: string
+  db: string
+}
+
+type CommentDecision = 'set' | 'clear' | 'skip' | 'quit'
+
+interface CommentSummary {
+  updated: number
+  cleared: number
+  skipped: number
+}
+
+function toTransactionFilters(options: CommentOptions): TransactionFilters {
+  return { ...toBaseFilters(options) }
+}
+
+function loadById(db: Database, id: number): Transaction[] {
+  const transaction = getTransactionById(db, id)
+  if (transaction === undefined) return []
+  return [transaction]
+}
+
+function loadByFilters(db: Database, options: CommentOptions): Transaction[] {
+  return getTransactions(db, toTransactionFilters(options))
+}
+
+function loadTransactions(db: Database, id: number | undefined, options: CommentOptions): Transaction[] {
+  if (id !== undefined) return loadById(db, id)
+  return loadByFilters(db, options)
+}
+
+function formatTransactionNote(transaction: Transaction, index: number, total: number): string {
+  const lines = [
+    `[${index}/${total}]  ${transaction.date}  ${formatAmount(transaction.amount)} EUR`,
+    `Counterparty : ${transaction.counterparty}`,
+  ]
+  if (transaction.bankCommunication !== undefined) lines.push(`Bank note    : ${transaction.bankCommunication}`)
+  if (transaction.comment !== undefined) lines.push(`Comment      : ${transaction.comment}`)
+  return lines.join('\n')
+}
+
+function decisionOptionsFor(hasComment: boolean) {
+  const options = [
+    { value: 'set' as CommentDecision, label: hasComment ? 'Update comment' : 'Add comment' },
+    { value: 'skip' as CommentDecision, label: 'Skip' },
+    { value: 'quit' as CommentDecision, label: 'Quit' },
+  ]
+  if (hasComment) options.splice(1, 0, { value: 'clear' as CommentDecision, label: 'Clear comment' })
+  return options
+}
+
+async function promptDecision(transaction: Transaction, index: number, total: number): Promise<CommentDecision> {
+  note(formatTransactionNote(transaction, index, total), 'Transaction')
+
+  const decision = await select({
+    message: 'What do you want to do?',
+    options: decisionOptionsFor(transaction.comment !== undefined),
+  })
+
+  if (isCancel(decision)) return 'quit'
+  return decision
+}
+
+async function promptComment(current: string | undefined): Promise<string | symbol> {
+  return text({
+    message: 'Enter comment:',
+    initialValue: current ?? '',
+    placeholder: 'Leave blank to skip',
+  })
+}
+
+async function applyDecision(
+  db: Database,
+  decision: CommentDecision,
+  transaction: Transaction,
+): Promise<CommentDecision> {
+  if (transaction.id === undefined) return 'skip'
+
+  if (decision === 'clear') {
+    updateComment(db, transaction.id, undefined)
+    log.success('Comment cleared')
+    return 'clear'
+  }
+
+  if (decision === 'set') {
+    const input = await promptComment(transaction.comment)
+    if (isCancel(input)) return 'quit'
+    const trimmed = (input as string).trim()
+    if (trimmed === '') return 'skip'
+    updateComment(db, transaction.id, trimmed)
+    log.success('Comment saved')
+    return 'set'
+  }
+
+  return decision
+}
+
+async function annotateTransactions(db: Database, transactions: Transaction[]): Promise<CommentSummary> {
+  const summary: CommentSummary = { updated: 0, cleared: 0, skipped: 0 }
+
+  for (let i = 0; i < transactions.length; i++) {
+    const decision = await promptDecision(transactions[i], i + 1, transactions.length)
+    if (decision === 'quit') break
+
+    const outcome = await applyDecision(db, decision, transactions[i])
+    if (outcome === 'quit') break
+    if (outcome === 'set') summary.updated++
+    if (outcome === 'clear') summary.cleared++
+    if (outcome === 'skip') summary.skipped++
+  }
+
+  return summary
+}
+
+function formatSummary(summary: CommentSummary, total: number): string {
+  const acted = summary.updated + summary.cleared
+  return `Reviewed ${acted + summary.skipped}/${total} — ${summary.updated} updated, ${summary.cleared} cleared, ${summary.skipped} skipped`
+}
+
+async function commentAction(idArg: string | undefined, options: CommentOptions): Promise<void> {
+  intro('Transaction Comments')
+
+  let database: Database | undefined
+  const onCancel = () => {
+    database?.close()
+    cancel('Cancelled.')
+    process.exit(1)
+  }
+  process.once('SIGINT', onCancel)
+
+  try {
+    const dbPath = resolve(options.db)
+    database = openDatabase(dbPath)
+
+    const id = idArg !== undefined ? Number.parseInt(idArg, 10) : undefined
+    if (idArg !== undefined && (Number.isNaN(id!) || id! <= 0)) {
+      process.removeListener('SIGINT', onCancel)
+      database.close()
+      log.error(`Invalid transaction ID: ${idArg}`)
+      process.exit(1)
+      return
+    }
+
+    const transactions = loadTransactions(database, id, options)
+
+    if (transactions.length === 0) {
+      process.removeListener('SIGINT', onCancel)
+      database.close()
+      log.info(id !== undefined ? `No transaction found with ID ${id}.` : 'No transactions match the given filters.')
+      outro('Done')
+      return
+    }
+
+    log.info(`Found ${transactions.length} transaction${transactions.length === 1 ? '' : 's'}.`)
+
+    const summary = await annotateTransactions(database, transactions)
+
+    process.removeListener('SIGINT', onCancel)
+    database.close()
+    outro(formatSummary(summary, transactions.length))
+  } catch (error) {
+    process.removeListener('SIGINT', onCancel)
+    database?.close()
+    log.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}
+
+export function createCommentCommand(defaultDb: string): Command {
+  return new Command('comment')
+    .description('Interactively add or edit comments on transactions before categorization')
+    .argument('[id]', 'transaction ID to comment on directly')
+    .option('-f, --from <date>', 'filter from date (YYYY-MM-DD)')
+    .option('-t, --to <date>', 'filter to date (YYYY-MM-DD)')
+    .option('-s, --search <text>', 'search counterparty')
+    .option('-l, --limit <n>', 'max transactions to review')
+    .option('-d, --db <path>', 'SQLite database path', defaultDb)
+    .action(commentAction)
+}

--- a/src/commands/transactions/index.test.ts
+++ b/src/commands/transactions/index.test.ts
@@ -7,6 +7,6 @@ describe('createTransactionsCommand', () => {
     const command = await createTransactionsCommand()
     const subcommandNames = command.commands.map((subcommand) => subcommand.name())
 
-    expect(subcommandNames).toEqual(['import', 'categorize', 'list', 'categories', 'suggestions'])
+    expect(subcommandNames).toEqual(['import', 'comment', 'categorize', 'list', 'categories', 'suggestions'])
   })
 })

--- a/src/commands/transactions/index.ts
+++ b/src/commands/transactions/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { resolveDbPath } from '@/config'
 import { createCategoriesCommand } from './categories/index'
 import { createCategorizeCommand } from './categorize'
+import { createCommentCommand } from './comment'
 import { createImportCommand } from './import'
 import { createListCommand } from './list'
 import { createSuggestionsCommand } from './suggestions/index'
@@ -11,6 +12,7 @@ export async function createTransactionsCommand(): Promise<Command> {
   return new Command('transactions')
     .description('Manage stored transactions')
     .addCommand(createImportCommand(defaultDb))
+    .addCommand(createCommentCommand(defaultDb))
     .addCommand(createCategorizeCommand(defaultDb))
     .addCommand(createListCommand(defaultDb))
     .addCommand(createCategoriesCommand(defaultDb))

--- a/src/db/transactions/queries.test.ts
+++ b/src/db/transactions/queries.test.ts
@@ -12,6 +12,7 @@ import { insertTransaction, updateCategory } from './mutations'
 import { createTransactionsTable } from './schema'
 import {
   countTransactions,
+  getTransactionById,
   getTransactions,
   getTransactionsMissingCategoryForCategorization,
   getUncategorized,
@@ -338,5 +339,24 @@ describe('getTransactionsMissingCategoryForCategorization', () => {
     })
 
     expect(transactions).toHaveLength(2)
+  })
+})
+
+describe('getTransactionById', () => {
+  it('returns the transaction when it exists', () => {
+    insertTransaction(db, fakeTransaction)
+    const [inserted] = getTransactions(db)
+
+    const transaction = getTransactionById(db, inserted.id!)
+
+    expect(transaction).toBeDefined()
+    expect(transaction?.counterparty).toBe(fakeTransaction.counterparty)
+    expect(transaction?.amount).toBe(fakeTransaction.amount)
+  })
+
+  it('returns undefined when no transaction matches the given ID', () => {
+    const transaction = getTransactionById(db, 999)
+
+    expect(transaction).toBeUndefined()
   })
 })

--- a/src/db/transactions/queries.ts
+++ b/src/db/transactions/queries.ts
@@ -82,6 +82,12 @@ export function getUncategorized(db: Database): Transaction[] {
   return rows.map(rowToTransaction)
 }
 
+export function getTransactionById(db: Database, id: number): Transaction | undefined {
+  const row = db.prepare('SELECT * FROM transactions WHERE id = ?').get(id) as Record<string, unknown> | null
+  if (row === null) return undefined
+  return rowToTransaction(row)
+}
+
 export function hasTransactionsForAccount(db: Database, accountId: number): boolean {
   const row = db.prepare('SELECT 1 AS found FROM transactions WHERE account_id = ? LIMIT 1').get(accountId) as {
     found: number


### PR DESCRIPTION
## Summary

- Adds `transactions comment [id]` subcommand for annotating transactions before AI categorization
- Supports two modes: direct by ID (`transactions comment 42`) or interactive batch via filters (`--from`, `--to`, `--search`, `--limit`)
- For each transaction: shows date, amount, counterparty, bank note, and existing comment, then prompts to add/update, clear, skip, or quit
- Adds `getTransactionById` query to `src/db/transactions/queries.ts`

## Test plan

- [ ] `flouz transactions comment` with no arguments walks through all transactions
- [ ] `flouz transactions comment --from 2025-01-01 --search Delhaize` filters correctly
- [ ] `flouz transactions comment 42` jumps straight to transaction 42
- [ ] Invalid ID (non-numeric, zero, negative) exits with an error message
- [ ] ID not found exits with a "no transaction found" message
- [ ] Add/update saves the trimmed comment
- [ ] Blank input on the text prompt skips without saving
- [ ] Clear removes the comment
- [ ] Ctrl+C at any prompt cancels cleanly
- [ ] Running `transactions categorize` after commenting picks up the comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)