### PR TITLE
feat(transactions): expand --category filter to include descendant categories

### DIFF
--- a/src/commands/transactions/list.ts
+++ b/src/commands/transactions/list.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander'
 import { isBrokenPipeError, writeStdout } from '@/cli/stdout'
 import { resolve } from 'node:path'
 import { renderCliTable } from '@/cli/table'
-import { getCategories } from '@/db/categories/queries'
+import { collectDescendantIds, getCategories } from '@/db/categories/queries'
 import { openDatabase } from '@/db/schema'
 import { getTransactions } from '@/db/transactions/queries'
 import type { Category, Transaction, TransactionFilters } from '@/types'
@@ -41,11 +41,12 @@ async function ensureDatabaseExists(dbPath: string): Promise<void> {
   )
 }
 
-function resolveCategoryId(db: Database, categorySlug: string | undefined): string | undefined {
+function resolveCategoryIds(db: Database, categorySlug: string | undefined): string[] | undefined {
   if (categorySlug === undefined) return undefined
 
   const categories = getCategories(db)
-  return findCategoryId(categories, categorySlug)
+  const rootId = findCategoryId(categories, categorySlug)
+  return collectDescendantIds(categories, rootId)
 }
 
 export function findCategoryId(categories: Category[], categorySlug: string): string {
@@ -54,11 +55,11 @@ export function findCategoryId(categories: Category[], categorySlug: string): st
   throw new Error(`Unknown category slug: ${categorySlug}`)
 }
 
-function toTransactionFilters(options: ListOptions, categoryId: string | undefined): TransactionFilters {
+function toTransactionFilters(options: ListOptions, categoryIds: string[] | undefined): TransactionFilters {
   return {
     from: options.from,
     to: options.to,
-    categoryId,
+    categoryIds,
     search: options.search,
     limit: parseLimit(options.limit),
     uncategorized: options.uncategorized,
@@ -77,8 +78,8 @@ function parseLimit(limit: string | undefined): number | undefined {
 }
 
 function loadListData(db: Database, options: ListOptions): ListData {
-  const categoryId = resolveCategoryId(db, options.category)
-  const filters = toTransactionFilters(options, categoryId)
+  const categoryIds = resolveCategoryIds(db, options.category)
+  const filters = toTransactionFilters(options, categoryIds)
   return {
     transactions: getTransactions(db, filters),
   }

--- a/src/db/categories/queries.test.ts
+++ b/src/db/categories/queries.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'bun:test'
 import { Database } from 'bun:sqlite'
 import { CATEGORIES } from '@/data/categories'
 import { createCategoriesTable } from './schema'
-import { getCategories } from './queries'
+import { collectDescendantIds, getCategories } from './queries'
 import { seedCategories } from './seed'
 
 let db: Database
@@ -17,5 +17,45 @@ describe('getCategories', () => {
   it('returns all categories', () => {
     const categories = getCategories(db)
     expect(categories.length).toBe(CATEGORIES.length)
+  })
+})
+
+describe('collectDescendantIds', () => {
+  it('returns only the root id when the category has no children', () => {
+    const groceries = CATEGORIES.find((category) => category.slug === 'groceries')!
+
+    const ids = collectDescendantIds(CATEGORIES, groceries.id)
+
+    expect(ids).toEqual([groceries.id])
+  })
+
+  it('includes the category and all its direct children', () => {
+    const transport = CATEGORIES.find((category) => category.slug === 'transport')!
+    const transportChildren = CATEGORIES.filter((category) => category.parentId === transport.id)
+
+    const ids = collectDescendantIds(CATEGORIES, transport.id)
+
+    expect(ids).toContain(transport.id)
+    for (const child of transportChildren) {
+      expect(ids).toContain(child.id)
+    }
+  })
+
+  it('includes grandchildren', () => {
+    const discretionary = CATEGORIES.find((category) => category.slug === 'discretionary')!
+    const restaurant = CATEGORIES.find((category) => category.slug === 'restaurant')!
+
+    const ids = collectDescendantIds(CATEGORIES, discretionary.id)
+
+    expect(ids).toContain(restaurant.id)
+  })
+
+  it('does not include unrelated categories', () => {
+    const savings = CATEGORIES.find((category) => category.slug === 'savings')!
+    const groceries = CATEGORIES.find((category) => category.slug === 'groceries')!
+
+    const ids = collectDescendantIds(CATEGORIES, savings.id)
+
+    expect(ids).not.toContain(groceries.id)
   })
 })

--- a/src/db/categories/queries.ts
+++ b/src/db/categories/queries.ts
@@ -19,3 +19,12 @@ export function getCategories(db: Database): Category[] {
     parentId: (row.parent_id as string | null) ?? null,
   }))
 }
+
+export function collectDescendantIds(categories: Category[], rootId: string): string[] {
+  const ids = [rootId]
+  const children = categories.filter((category) => category.parentId === rootId)
+  for (const child of children) {
+    ids.push(...collectDescendantIds(categories, child.id))
+  }
+  return ids
+}

--- a/src/db/transactions/queries.test.ts
+++ b/src/db/transactions/queries.test.ts
@@ -94,10 +94,10 @@ describe('getTransactions', () => {
     expect(transactions.length).toBe(2)
   })
 
-  it('filters by categoryId', () => {
+  it('filters by categoryIds', () => {
     const allTransactions = getTransactions(db)
     updateCategory(db, allTransactions[0].id!, 'food-groceries')
-    const transactions = getTransactions(db, { categoryId: 'food-groceries' })
+    const transactions = getTransactions(db, { categoryIds: ['food-groceries'] })
     expect(transactions.length).toBe(1)
   })
 

--- a/src/db/transactions/queries.ts
+++ b/src/db/transactions/queries.ts
@@ -36,9 +36,10 @@ function buildFilterQueryParts(filters: TransactionFilters): FilterQueryParts {
     conditions.push('date <= ?')
     params.push(filters.to)
   }
-  if (filters.categoryId !== undefined) {
-    conditions.push('category_id = ?')
-    params.push(filters.categoryId)
+  if (filters.categoryIds !== undefined && filters.categoryIds.length > 0) {
+    const placeholders = filters.categoryIds.map(() => '?').join(', ')
+    conditions.push(`category_id IN (${placeholders})`)
+    params.push(...filters.categoryIds)
   }
   if (filters.search !== undefined) {
     conditions.push('counterparty LIKE ?')

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export type ImportedTransaction = Omit<NewTransaction, 'accountId'> & {
 export interface TransactionFilters {
   from?: string
   to?: string
-  categoryId?: string
+  categoryIds?: string[]
   search?: string
   limit?: number
   uncategorized?: boolean


### PR DESCRIPTION
## Summary

- Filtering by `--category <slug>` now returns transactions categorized under the selected category **and all its descendant categories** (children and grandchildren)
- Added `collectDescendantIds(categories, rootId)` to `src/db/categories/queries.ts` — recursively collects a category ID and all its descendants
- Changed `TransactionFilters.categoryId?: string` → `categoryIds?: string[]` so the SQL filter uses `IN (...)` instead of `=`

## Test plan

- [ ] `bun test src/db/categories/queries.test.ts` — 4 new tests for `collectDescendantIds` (leaf, children, grandchildren, unrelated exclusion)
- [ ] `bun test src/db/transactions/queries.test.ts` — updated existing category filter test to use `categoryIds`
- [ ] `bun test` — full suite (385 tests, 0 failures)
- [ ] Manual: `flouz transactions list --category transport` returns transactions under `public-transport`, `parking`, `car`, and `bicycle` as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)