### PR TITLE
fix(transactions): make --override lift suggestion-exists restriction

### DIFF
--- a/src/db/transactions/queries.test.ts
+++ b/src/db/transactions/queries.test.ts
@@ -361,6 +361,43 @@ describe('getTransactionsEligibleForCategorization', () => {
 
     expect(transactions).toHaveLength(0)
   })
+
+  it('includes transactions with existing suggestions when override is true', () => {
+    insertTransaction(db, { ...fakeTransaction, counterparty: 'Already Suggested' })
+    const allTransactions = getTransactions(db)
+    const transactionId = allTransactions[0].id!
+
+    upsertTransactionCategorySuggestion(db, {
+      transactionId,
+      categoryId: CATEGORY_ID,
+      confidence: 0.9,
+      model: 'test-model',
+    })
+
+    const transactions = getTransactionsEligibleForCategorization(db, { override: true })
+
+    expect(transactions).toHaveLength(1)
+    expect(transactions[0].counterparty).toBe('Already Suggested')
+  })
+
+  it('includes transactions that are both categorized and have a suggestion when override is true', () => {
+    insertTransaction(db, { ...fakeTransaction, counterparty: 'Recategorize Me' })
+    const allTransactions = getTransactions(db)
+    const transactionId = allTransactions[0].id!
+
+    updateCategory(db, transactionId, CATEGORY_ID)
+    upsertTransactionCategorySuggestion(db, {
+      transactionId,
+      categoryId: CATEGORY_ID,
+      confidence: 0.9,
+      model: 'test-model',
+    })
+
+    const transactions = getTransactionsEligibleForCategorization(db, { override: true })
+
+    expect(transactions).toHaveLength(1)
+    expect(transactions[0].counterparty).toBe('Recategorize Me')
+  })
 })
 
 describe('getTransactionById', () => {

--- a/src/db/transactions/queries.ts
+++ b/src/db/transactions/queries.ts
@@ -101,9 +101,13 @@ export function getTransactionsEligibleForCategorization(
   db: Database,
   filters: CategorizeTransactionsFilters = {},
 ): Transaction[] {
-  const conditions: string[] = ['id NOT IN (SELECT transaction_id FROM transaction_category_suggestions)']
-  if (!filters.override) conditions.unshift('category_id IS NULL')
+  const conditions: string[] = []
   const params: SQLQueryBindings[] = []
+
+  if (!filters.override) {
+    conditions.push('category_id IS NULL')
+    conditions.push('id NOT IN (SELECT transaction_id FROM transaction_category_suggestions)')
+  }
 
   if (filters.from !== undefined) {
     conditions.push('date >= ?')
@@ -118,7 +122,7 @@ export function getTransactionsEligibleForCategorization(
     params.push(`%${filters.search}%`)
   }
 
-  const whereClause = `WHERE ${conditions.join(' AND ')}`
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
   const limitClause = filters.limit !== undefined ? 'LIMIT ?' : ''
 
   if (filters.limit !== undefined) {


### PR DESCRIPTION
## Summary

- `getTransactionsEligibleForCategorization` unconditionally excluded transactions with any existing row in `transaction_category_suggestions`, so `--override` only removed the `category_id IS NULL` guard — transactions with suggestions were still silently skipped
- Both restrictions (`category_id IS NULL` and `id NOT IN (SELECT ... FROM transaction_category_suggestions)`) are now gated on `!filters.override`, enabling actual recategorization
- Made the WHERE clause conditional to avoid invalid SQL when `override` is true and no other filters are set

## Test plan

- [ ] `includes transactions with existing suggestions when override is true` — verifies the previously broken case
- [ ] `includes transactions that are both categorized and have a suggestion when override is true` — verifies the full recategorization path
- [ ] Existing tests continue to pass: suggestion-exists exclusion without override, categorized-exclusion without override

🤖 Generated with [Claude Code](https://claude.com/claude-code)