### PR TITLE
Add date filters to transaction import

### DIFF
--- a/src/commands/transactions/import.action.test.ts
+++ b/src/commands/transactions/import.action.test.ts
@@ -15,6 +15,7 @@ import { createAccountsTable } from '@/db/accounts/schema'
 import { createTransactionsTable } from '@/db/transactions/schema'
 import { createTransactionCategorySuggestionsTable } from '@/db/transaction_category_suggestions/schema'
 import { insertAccount } from '@/db/accounts/mutations'
+import { getTransactions } from '@/db/transactions/queries'
 import type { Command } from 'commander'
 
 const FIXTURE = `${import.meta.dir}/../../parsers/__fixtures__/minimal.csv`
@@ -169,5 +170,67 @@ describe('importAction — successful import from fixture file', () => {
     )
 
     expect(summary).toEqual({ status: 'resolved' })
+  })
+
+  it('imports only transactions inside the inclusive date range and reports ignored rows', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    openDatabaseMock.mockReturnValue(handle)
+
+    const summary = await collectCommandOutcome<ImportOutcome>(
+      async () => {
+        const command = createImportCommand('default.db')
+        command.configureOutput({ writeErr: () => {}, writeOut: () => {} })
+        await command.parseAsync(['--from', '2026-01-16', '--to', '2026-01-18', FIXTURE], { from: 'user' })
+      },
+      () => ({ status: 'resolved' }),
+      (errorCode) => ({ status: 'rejected', errorCode }),
+    )
+
+    const transactions = getTransactions(database)
+    expect({
+      summary,
+      dates: transactions.map((transaction) => transaction.date),
+      message: outroMock.mock.calls[0][0],
+    }).toEqual({
+      summary: { status: 'resolved' },
+      dates: ['2026-01-18', '2026-01-17', '2026-01-16'],
+      message: '✓ 3 imported, 2 ignored by date filter',
+    })
+  })
+})
+
+describe('importAction — invalid date filters', () => {
+  it('logs an error and exits with code 1 for an invalid --from date', async () => {
+    const summary = await collectCommandOutcome<ImportOutcome>(
+      async () => {
+        const command = createImportCommand('default.db')
+        command.configureOutput({ writeErr: () => {}, writeOut: () => {} })
+        await command.parseAsync(['--from', '2026-02-31', FIXTURE], { from: 'user' })
+      },
+      () => ({ status: 'resolved' }),
+      (errorCode) => ({ status: 'rejected', errorCode }),
+    )
+
+    expect({ summary, error: logErrorMock.mock.calls[0][0] }).toEqual({
+      summary: { status: 'rejected', errorCode: 1 },
+      error: 'Invalid --from date: 2026-02-31. Use YYYY-MM-DD.',
+    })
+  })
+
+  it('logs an error and exits with code 1 when --from is after --to', async () => {
+    const summary = await collectCommandOutcome<ImportOutcome>(
+      async () => {
+        const command = createImportCommand('default.db')
+        command.configureOutput({ writeErr: () => {}, writeOut: () => {} })
+        await command.parseAsync(['--from', '2026-01-19', '--to', '2026-01-15', FIXTURE], { from: 'user' })
+      },
+      () => ({ status: 'resolved' }),
+      (errorCode) => ({ status: 'rejected', errorCode }),
+    )
+
+    expect({ summary, error: logErrorMock.mock.calls[0][0] }).toEqual({
+      summary: { status: 'rejected', errorCode: 1 },
+      error: 'Invalid date range: --from 2026-01-19 is after --to 2026-01-15.',
+    })
   })
 })

--- a/src/commands/transactions/import.test.ts
+++ b/src/commands/transactions/import.test.ts
@@ -7,10 +7,37 @@ import { initDb } from '@/db/schema'
 import { insertTransaction } from '@/db/transactions/mutations'
 import { getTransactions } from '@/db/transactions/queries'
 import { parseCsv } from '@/parsers/csv'
-import { findCsvFiles, resolveImportedTransaction } from './import'
+import { getArgumentSetup } from '@/commands/test-helpers'
+import { createImportCommand, findCsvFiles, resolveImportedTransaction } from './import'
 
 const FIXTURE = `${import.meta.dir}/../../parsers/__fixtures__/minimal.csv`
 const FIXTURES_DIR = `${import.meta.dir}/../../parsers/__fixtures__`
+
+describe('createImportCommand', () => {
+  it('creates the command with name "import"', () => {
+    expect(createImportCommand('flouz.db').name()).toBe('import')
+  })
+
+  it('registers <path> as a required non-variadic positional argument', () => {
+    const argument = getArgumentSetup(createImportCommand('flouz.db'), 0)
+    expect(argument).toMatchObject({ name: 'path', required: true, variadic: false })
+  })
+
+  it('has --from option', () => {
+    const option = createImportCommand('flouz.db').options.find((option) => option.long === '--from')
+    expect(option).toBeDefined()
+  })
+
+  it('has --to option', () => {
+    const option = createImportCommand('flouz.db').options.find((option) => option.long === '--to')
+    expect(option).toBeDefined()
+  })
+
+  it('registers --db option with the supplied default path', () => {
+    const option = createImportCommand('my.db').options.find((option) => option.long === '--db')
+    expect(option?.defaultValue).toBe('my.db')
+  })
+})
 
 async function importAll(db: Database, sourceFile: string): Promise<{ imported: number; errors: number }> {
   const content = await Bun.file(sourceFile).text()

--- a/src/commands/transactions/import.ts
+++ b/src/commands/transactions/import.ts
@@ -22,6 +22,22 @@ interface InsertResult {
   allErrors: (ParseError & { file: string })[]
 }
 
+interface ImportOptions {
+  db: string
+  from?: string
+  to?: string
+}
+
+interface DateFilter {
+  from?: string
+  to?: string
+}
+
+interface FilteredParsedFiles {
+  parsed: ParsedFile[]
+  ignoredByFilter: number
+}
+
 export function resolveImportedTransaction(db: Database, transaction: ImportedTransaction): NewTransaction {
   const accountId = resolveAccountId(db, transaction.accountKey)
   return {
@@ -69,6 +85,57 @@ async function parseAllFiles(files: string[]): Promise<ParsedFile[]> {
   return parsed
 }
 
+function validateDateFilter(options: ImportOptions): DateFilter {
+  validateDateOption('from', options.from)
+  validateDateOption('to', options.to)
+  if (options.from !== undefined && options.to !== undefined && options.from > options.to) {
+    throw new Error(`Invalid date range: --from ${options.from} is after --to ${options.to}.`)
+  }
+
+  return {
+    from: options.from,
+    to: options.to,
+  }
+}
+
+function validateDateOption(optionName: string, value: string | undefined): void {
+  if (value === undefined) return
+  if (isCalendarDate(value)) return
+  throw new Error(`Invalid --${optionName} date: ${value}. Use YYYY-MM-DD.`)
+}
+
+function isCalendarDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+
+  const parsedDate = new Date(`${value}T00:00:00.000Z`)
+  return parsedDate.toISOString().slice(0, 10) === value
+}
+
+function applyDateFilter(parsed: ParsedFile[], filter: DateFilter): FilteredParsedFiles {
+  if (filter.from === undefined && filter.to === undefined) {
+    return { parsed, ignoredByFilter: 0 }
+  }
+
+  let ignoredByFilter = 0
+  const filteredParsed = parsed.map(({ file, transactions, errors }) => {
+    const filteredTransactions = transactions.filter((transaction) => {
+      const shouldImport = isWithinDateFilter(transaction.date, filter)
+      if (!shouldImport) ignoredByFilter++
+      return shouldImport
+    })
+
+    return { file, transactions: filteredTransactions, errors }
+  })
+
+  return { parsed: filteredParsed, ignoredByFilter }
+}
+
+function isWithinDateFilter(date: string, filter: DateFilter): boolean {
+  if (filter.from !== undefined && date < filter.from) return false
+  if (filter.to !== undefined && date > filter.to) return false
+  return true
+}
+
 async function insertAllTransactions(db: Database, parsed: ParsedFile[]): Promise<InsertResult> {
   const totalRows = parsed.reduce((sum, { transactions }) => sum + transactions.length, 0)
   const insertProgress = progress({
@@ -111,16 +178,29 @@ function resolveAccountId(db: Database, accountKey: string | undefined): number 
   throw new Error(`Unknown account key: ${normalizedKey}. Create it first with \`flouz accounts add\`.`)
 }
 
-function reportResults(totalImported: number, allErrors: (ParseError & { file: string })[]): void {
+function reportResults(
+  totalImported: number,
+  allErrors: (ParseError & { file: string })[],
+  ignoredByFilter: number,
+): void {
   for (const { file, row, message } of allErrors) {
     log.warn(`${file} line ${row}: ${message}`)
   }
   const errorSuffix = allErrors.length > 0 ? `, ${allErrors.length} invalid row(s) skipped` : ''
-  outro(`${ICON_SUCCESS} ${totalImported} imported${errorSuffix}`)
+  const filterSuffix = ignoredByFilter > 0 ? `, ${ignoredByFilter} ignored by date filter` : ''
+  outro(`${ICON_SUCCESS} ${totalImported} imported${filterSuffix}${errorSuffix}`)
 }
 
-async function importAction(path: string, options: { db: string }): Promise<void> {
+async function importAction(path: string, options: ImportOptions): Promise<void> {
   intro('flouz transactions import')
+
+  let dateFilter: DateFilter
+  try {
+    dateFilter = validateDateFilter(options)
+  } catch (error) {
+    log.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
 
   const files = await resolveCsvFiles(path)
   if (!files) {
@@ -147,10 +227,11 @@ async function importAction(path: string, options: { db: string }): Promise<void
 
   try {
     const parsed = await parseAllFiles(files)
-    const { totalImported, allErrors } = await insertAllTransactions(database, parsed)
+    const filtered = applyDateFilter(parsed, dateFilter)
+    const { totalImported, allErrors } = await insertAllTransactions(database, filtered.parsed)
     process.removeListener('SIGINT', onCancel)
     database.close()
-    reportResults(totalImported, allErrors)
+    reportResults(totalImported, allErrors, filtered.ignoredByFilter)
   } catch (error) {
     process.removeListener('SIGINT', onCancel)
     log.error(error instanceof Error ? error.message : String(error))
@@ -163,6 +244,8 @@ export function createImportCommand(defaultDb: string): Command {
   return new Command('import')
     .description('Import transactions from a CSV file or directory of CSV files')
     .argument('<path>', 'path to CSV file or directory')
+    .option('-f, --from <date>', 'import from date (yyyy-MM-dd)')
+    .option('-t, --to <date>', 'import to date (yyyy-MM-dd)')
     .option('-d, --db <path>', 'SQLite database path', defaultDb)
     .action(importAction)
 }


### PR DESCRIPTION
## Summary
- add --from and --to options to transactions import
- validate YYYY-MM-DD date filters and reject reversed ranges
- report how many parsed transactions were ignored by the date filter

## Tests
- bun test src/commands/transactions/import.test.ts src/commands/transactions/import.action.test.ts
- bun test
- bun run typecheck
- bun run lint