### PR TITLE
Add resume flag to transaction comments

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -25,6 +25,9 @@ flouz — AI-powered personal finance CLI for bank transactions
     ├── categorize — AI-categorize uncategorized transactions
     │   Options: -f/--from <date>, -t/--to <date>, -s/--search <text>,
     │            -l/--limit <n>, -d/--db <path>
+    ├── comment [id] — Interactively add or edit transaction comments
+    │   Options: -f/--from <date>, -t/--to <date>, -s/--search <text>,
+    │            -l/--limit <n>, --resume, -d/--db <path>
     ├── categories — Manage transaction categories
     │   └── list — List available transaction categories
     │       Options: --tree, -d/--db <path>

--- a/skills/flouz/transactions-comment.md
+++ b/skills/flouz/transactions-comment.md
@@ -6,8 +6,9 @@ Interactively add or edit free-text comments on transactions. Comments are visib
 flouz transactions comment                        # review all
 flouz transactions comment 42                     # jump to transaction 42
 flouz transactions comment --search virement --limit 10
+flouz transactions comment --resume               # restart at the last commented transaction
 ```
 
-Options: `-f, --from`, `-t, --to`, `-s, --search`, `-l, --limit`, `-d, --db`
+Options: `-f, --from`, `-t, --to`, `-s, --search`, `-l, --limit`, `--resume`, `-d, --db`
 
 Interactive choices: **Add/Update comment**, **Clear comment**, **Skip**, **Quit**

--- a/src/commands/transactions/README.md
+++ b/src/commands/transactions/README.md
@@ -6,6 +6,7 @@ The `transactions` command groups the main workflows for working with stored tra
 
 - `import` reads CSV data and inserts valid rows into the database
 - `list` prints stored transactions as a table, CSV, or JSON
+- `comment` interactively adds notes that can help categorization
 - `categorize` runs AI categorization on uncategorized transactions and stores suggestions
 - `suggestions` reviews, approves, rejects, and applies AI-generated suggestions
 
@@ -41,6 +42,23 @@ flouz transactions list [options]
 | `-d, --db <path>`       | SQLite database path                                        |
 
 `--category` and `--uncategorized` are mutually exclusive.
+
+### `comment`
+
+Interactively adds or edits free-text comments on transactions before categorization.
+
+```bash
+flouz transactions comment [id] [options]
+```
+
+| Option                | Description                                           |
+| --------------------- | ----------------------------------------------------- |
+| `-f, --from <date>`   | Review only transactions from this date (YYYY-MM-DD)  |
+| `-t, --to <date>`     | Review only transactions up to this date (YYYY-MM-DD) |
+| `-s, --search <text>` | Filter by counterparty name                           |
+| `-l, --limit <n>`     | Max transactions to review                            |
+| `--resume`            | Start at the last commented transaction               |
+| `-d, --db <path>`     | SQLite database path                                  |
 
 ### `categorize`
 

--- a/src/commands/transactions/comment.test.ts
+++ b/src/commands/transactions/comment.test.ts
@@ -82,6 +82,10 @@ function getComment(database: Database, id: number): string | null {
   return row?.comment ?? null
 }
 
+function setComment(database: Database, id: number, comment: string): void {
+  database.prepare('UPDATE transactions SET comment = ? WHERE id = ?').run(comment, id)
+}
+
 async function runCommentCommand(database: Database, args: string[]): Promise<void> {
   openDatabaseMock.mockReturnValue(database)
   await runCommandSilently(createCommentCommand('default.db'), args)
@@ -142,6 +146,11 @@ describe('createCommentCommand', () => {
 
   it('has --limit option', () => {
     const option = createCommentCommand('flouz.db').options.find((option) => option.long === '--limit')
+    expect(option).toBeDefined()
+  })
+
+  it('has --resume option', () => {
+    const option = createCommentCommand('flouz.db').options.find((option) => option.long === '--resume')
     expect(option).toBeDefined()
   })
 
@@ -361,6 +370,62 @@ describe('comment action — filters', () => {
     expect({ comment1: getComment(database, id1), comment2: getComment(database, id2) }).toEqual({
       comment1: 'Matched',
       comment2: null,
+    })
+  })
+})
+
+describe('comment action — resume', () => {
+  it('starts at the last commented transaction in review order', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, { ...baseTransaction, date: '2026-01-03', counterparty: 'Newest Shop' })
+    const newestId = getLastId(database)
+    insertTransaction(database, { ...baseTransaction, date: '2026-01-02', counterparty: 'Resume Shop' })
+    const resumeId = getLastId(database)
+    setComment(database, resumeId, 'last pass')
+    insertTransaction(database, { ...baseTransaction, date: '2026-01-01', counterparty: 'Oldest Shop' })
+    const oldestId = getLastId(database)
+    selectResponseQueue.push('set', 'set')
+    textResponseQueue.push('updated resume point', 'older transaction')
+
+    await runCommentCommand(handle, ['--resume'])
+
+    expect({
+      newest: getComment(database, newestId),
+      resume: getComment(database, resumeId),
+      oldest: getComment(database, oldestId),
+    }).toEqual({
+      newest: null,
+      resume: 'updated resume point',
+      oldest: 'older transaction',
+    })
+  })
+
+  it('applies --limit after finding the resume point', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertTransaction(database, { ...baseTransaction, date: '2026-01-05', counterparty: 'Newest Shop' })
+    const newestId = getLastId(database)
+    insertTransaction(database, { ...baseTransaction, date: '2026-01-04', counterparty: 'Resume Shop' })
+    const resumeId = getLastId(database)
+    setComment(database, resumeId, 'last pass')
+    insertTransaction(database, { ...baseTransaction, date: '2026-01-03', counterparty: 'First Older Shop' })
+    const firstOlderId = getLastId(database)
+    insertTransaction(database, { ...baseTransaction, date: '2026-01-02', counterparty: 'Second Older Shop' })
+    const secondOlderId = getLastId(database)
+    selectResponseQueue.push('set', 'set')
+    textResponseQueue.push('updated resume point', 'first older')
+
+    await runCommentCommand(handle, ['--resume', '--limit', '2'])
+
+    expect({
+      newest: getComment(database, newestId),
+      resume: getComment(database, resumeId),
+      firstOlder: getComment(database, firstOlderId),
+      secondOlder: getComment(database, secondOlderId),
+    }).toEqual({
+      newest: null,
+      resume: 'updated resume point',
+      firstOlder: 'first older',
+      secondOlder: null,
     })
   })
 })

--- a/src/commands/transactions/comment.ts
+++ b/src/commands/transactions/comment.ts
@@ -9,13 +9,14 @@ import { openDatabase } from '@/db/schema'
 import { getTransactionById, getTransactions } from '@/db/transactions/queries'
 import { updateComment } from '@/db/transactions/mutations'
 import type { Transaction, TransactionFilters } from '@/types'
-import { toBaseFilters } from '@/commands/transactions/parse-options'
+import { parseLimit, toBaseFilters } from '@/commands/transactions/parse-options'
 
 interface CommentOptions {
   from?: string
   to?: string
   search?: string
   limit?: string
+  resume?: boolean
   db: string
 }
 
@@ -27,8 +28,10 @@ interface CommentSummary {
   skipped: number
 }
 
-function toTransactionFilters(options: CommentOptions): TransactionFilters {
-  return { ...toBaseFilters(options) }
+function toTransactionFilters(options: CommentOptions, includeLimit = true): TransactionFilters {
+  const filters = { ...toBaseFilters(options) }
+  if (!includeLimit) filters.limit = undefined
+  return filters
 }
 
 function loadById(db: Database, id: number): Transaction[] {
@@ -37,13 +40,25 @@ function loadById(db: Database, id: number): Transaction[] {
   return [transaction]
 }
 
-function loadByFilters(db: Database, options: CommentOptions): Transaction[] {
-  return getTransactions(db, toTransactionFilters(options))
+function loadByFilters(db: Database, options: CommentOptions, includeLimit = true): Transaction[] {
+  return getTransactions(db, toTransactionFilters(options, includeLimit))
 }
 
 function loadTransactions(db: Database, id: number | undefined, options: CommentOptions): Transaction[] {
   if (id !== undefined) return loadById(db, id)
   return loadByFilters(db, options)
+}
+
+function resumeFromLastCommented(transactions: Transaction[]): Transaction[] {
+  const lastCommentedIndex = transactions.findLastIndex((transaction) => transaction.comment !== undefined)
+  if (lastCommentedIndex === -1) return transactions
+  return transactions.slice(lastCommentedIndex)
+}
+
+function applyResume(transactions: Transaction[], options: CommentOptions): Transaction[] {
+  const resumed = resumeFromLastCommented(transactions)
+  const limit = parseLimit(options.limit)
+  return limit === undefined ? resumed : resumed.slice(0, limit)
 }
 
 function formatTransactionNote(transaction: Transaction, index: number, total: number): string {
@@ -162,7 +177,11 @@ async function commentAction(idArg: string | undefined, options: CommentOptions)
       return
     }
 
-    const transactions = loadTransactions(database, id, options)
+    const shouldResume = id === undefined && options.resume === true
+    const loadedTransactions = shouldResume
+      ? loadByFilters(database, options, false)
+      : loadTransactions(database, id, options)
+    const transactions = shouldResume ? applyResume(loadedTransactions, options) : loadedTransactions
 
     if (transactions.length === 0) {
       process.removeListener('SIGINT', onCancel)
@@ -197,6 +216,7 @@ export function createCommentCommand(defaultDb: string): Command {
     .option('-t, --to <date>', 'filter to date (YYYY-MM-DD)')
     .option('-s, --search <text>', 'search counterparty')
     .option('-l, --limit <n>', 'max transactions to review')
+    .option('--resume', 'start at the last commented transaction matching the filters')
     .option('-d, --db <path>', 'SQLite database path', defaultDb)
     .action(commentAction)
 }


### PR DESCRIPTION
## Summary
- add a --resume flag to restart comment review at the last commented transaction
- apply --limit after resolving the resume point
- document the new comment option

## Tests
- bun test src/commands/transactions/comment.test.ts
- bun run typecheck
- bun run lint
- bun run format:check