### PR TITLE
Add transfer and coffee categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,16 +184,17 @@ bun run src/index.ts accounts list
 
 ### Budgets
 
-Track monthly spending against budgets set on **top-level categories only**.
+Track monthly spending against budgets set on budgetable top-level categories.
 
-Available top-level categories (slugs):
+Available budget categories (slugs):
 
 | Slug            | Description                                       |
 | --------------- | ------------------------------------------------- |
 | `necessities`   | House, utilities, groceries, transport, health, … |
 | `savings`       | Savings accounts, investments                     |
 | `discretionary` | Food & drink, shopping, entertainment, travel, …  |
-| `income`        | Salary, reimbursements, gifts received            |
+
+`income` and `transfers` are category roots for classification and reporting, but they are excluded from budget setup.
 
 Budget checking aggregates all transactions in descendant categories under each top-level parent.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -88,10 +88,10 @@ Root (L1)
 ```
 
 - **L1 roots**: `Necessities`, `Savings`, `Discretionary`, `Transfers`, `Income` — `parent_id IS NULL`
-- **L2 nodes**: broad sub-groups — `parent_id` points to an L1 row
-- **L3 leaves**: specific categories used on transactions — `parent_id` points to an L2 row
+- **L2 nodes**: broad sub-groups or leaf categories — `parent_id` points to an L1 row
+- **L3 leaves**: specific categories nested under an L2 group — `parent_id` points to an L2 row
 
-Transactions are assigned to **L3 leaves** only.
+Transactions are assigned to **leaf categories** only.
 
 ## Key Rules
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -73,16 +73,21 @@ Root (L1)
 ├── Savings
 │   ├── Emergency Fund
 │   └── Investments
-└── Discretionary
-    ├── Food & Drink
-    │   ├── Restaurants
-    │   └── Coffee
-    └── Entertainment
-        ├── Streaming
-        └── Events
+├── Discretionary
+│   ├── Food & Drink
+│   │   ├── Restaurants
+│   │   └── Coffee
+│   └── Entertainment
+│       ├── Streaming
+│       └── Events
+├── Transfers
+│   └── Internal Transfer
+└── Income
+    ├── Salary
+    └── Reimbursement
 ```
 
-- **L1 roots**: `Necessities`, `Savings`, `Discretionary` — `parent_id IS NULL`
+- **L1 roots**: `Necessities`, `Savings`, `Discretionary`, `Transfers`, `Income` — `parent_id IS NULL`
 - **L2 nodes**: broad sub-groups — `parent_id` points to an L1 row
 - **L3 leaves**: specific categories used on transactions — `parent_id` points to an L2 row
 

--- a/src/commands/budget/README.md
+++ b/src/commands/budget/README.md
@@ -14,12 +14,13 @@ Manage monthly budgets and track spending against them.
 
 ## Category Constraints
 
-Budgets can **only** be set on top-level categories (those with `parentId: null`):
+Budgets can **only** be set on budgetable top-level categories:
 
 - `necessities` — House, Utilities, Groceries, Transport, Health, Insurance, Fees & Taxes, Cash & ATM
 - `savings` — Savings Account, Investments
 - `discretionary` — Food & Drink, Shopping, Entertainment, Travel, Gifts & Charity, Online Services
-- `income` — Salary, Reimbursement, Gifts Received, Other Income
+
+`income` and `transfers` are category roots for classification and reporting, but they are excluded from budget setup.
 
 When checking budget progress, spending is aggregated across all descendant categories under each top-level parent.
 
@@ -46,7 +47,7 @@ flouz budget set             # prompts for category (select) then amount (text)
 flouz budget set necessities # prompts for amount only
 ```
 
-The category prompt shows all top-level non-income categories as a select list.
+The category prompt shows all budgetable top-level categories as a select list.
 
 ### Direct
 

--- a/src/commands/budget/budget-value.test.ts
+++ b/src/commands/budget/budget-value.test.ts
@@ -13,6 +13,7 @@ const baseCategories: Category[] = [
   { id: 'cat-3', name: 'Discretionary', slug: 'discretionary', parentId: null },
   { id: 'cat-4', name: 'Income', slug: 'income', parentId: null },
   { id: 'cat-5', name: 'Groceries', slug: 'groceries', parentId: 'cat-1' },
+  { id: 'cat-6', name: 'Transfers', slug: 'transfers', parentId: null },
 ]
 
 describe('parseBudgetValue', () => {
@@ -73,6 +74,12 @@ describe('findTopLevelCategory', () => {
       'Budgets can only be set on top-level categories',
     )
   })
+
+  it('throws when category is a non-budget root', () => {
+    expect(() => findTopLevelCategory(baseCategories, 'transfers')).toThrow(
+      'Budgets can only be set on spending and saving categories',
+    )
+  })
 })
 
 describe('formatBudgetConfirmation', () => {
@@ -92,7 +99,7 @@ describe('formatBudgetConfirmation', () => {
 })
 
 describe('getTopLevelBudgetCategories', () => {
-  it('returns only top-level non-income categories', () => {
+  it('returns only top-level budget categories', () => {
     const result = getTopLevelBudgetCategories(baseCategories)
     expect(result).toHaveLength(3)
   })
@@ -102,13 +109,21 @@ describe('getTopLevelBudgetCategories', () => {
     expect(result.some((category) => category.slug === 'income')).toBe(false)
   })
 
+  it('excludes the transfers category', () => {
+    const result = getTopLevelBudgetCategories(baseCategories)
+    expect(result.some((category) => category.slug === 'transfers')).toBe(false)
+  })
+
   it('excludes subcategories', () => {
     const result = getTopLevelBudgetCategories(baseCategories)
     expect(result.some((category) => category.slug === 'groceries')).toBe(false)
   })
 
   it('returns empty array when no budget categories exist', () => {
-    const incomeOnly: Category[] = [{ id: 'cat-1', name: 'Income', slug: 'income', parentId: null }]
-    expect(getTopLevelBudgetCategories(incomeOnly)).toHaveLength(0)
+    const nonBudgetCategories: Category[] = [
+      { id: 'cat-1', name: 'Income', slug: 'income', parentId: null },
+      { id: 'cat-2', name: 'Transfers', slug: 'transfers', parentId: null },
+    ]
+    expect(getTopLevelBudgetCategories(nonBudgetCategories)).toHaveLength(0)
   })
 })

--- a/src/commands/budget/budget-value.test.ts
+++ b/src/commands/budget/budget-value.test.ts
@@ -75,8 +75,14 @@ describe('findTopLevelCategory', () => {
     )
   })
 
-  it('throws when category is a non-budget root', () => {
+  it('throws when transfers category is a non-budget root', () => {
     expect(() => findTopLevelCategory(baseCategories, 'transfers')).toThrow(
+      'Budgets can only be set on spending and saving categories',
+    )
+  })
+
+  it('throws when income category is a non-budget root', () => {
+    expect(() => findTopLevelCategory(baseCategories, 'income')).toThrow(
       'Budgets can only be set on spending and saving categories',
     )
   })

--- a/src/commands/budget/budget-value.ts
+++ b/src/commands/budget/budget-value.ts
@@ -7,6 +7,7 @@ export interface ParsedBudgetValue {
 }
 
 const STRICT_NUMERIC = /^\d+(\.\d+)?$/
+const NON_BUDGET_ROOT_SLUGS = new Set(['income', 'transfers'])
 
 export function parseBudgetValue(value: string): ParsedBudgetValue {
   const trimmed = value.trim()
@@ -32,11 +33,14 @@ export function findTopLevelCategory(categories: Category[], slug: string): Cate
   if (category.parentId !== null) {
     throw new Error('Budgets can only be set on top-level categories')
   }
+  if (NON_BUDGET_ROOT_SLUGS.has(category.slug)) {
+    throw new Error('Budgets can only be set on spending and saving categories')
+  }
   return category
 }
 
 export function getTopLevelBudgetCategories(categories: Category[]): Category[] {
-  return categories.filter((category) => category.parentId === null && category.slug !== 'income')
+  return categories.filter((category) => category.parentId === null && !NON_BUDGET_ROOT_SLUGS.has(category.slug))
 }
 
 export function formatBudgetConfirmation(name: string, parsed: ParsedBudgetValue, month: string): string {

--- a/src/commands/budget/set.action.test.ts
+++ b/src/commands/budget/set.action.test.ts
@@ -329,6 +329,14 @@ describe('set action', () => {
     expect(outcome).toEqual({ status: 'rejected', errorCode: 1 })
   })
 
+  it('exits with code 1 for transfers budget slug', async () => {
+    const { handle } = createTestDatabase()
+    openDatabaseMock.mockReturnValue(handle)
+
+    const outcome = await collectSetOutcome(['transfers', '2000', '--month', '2026-03'])
+    expect(outcome).toEqual({ status: 'rejected', errorCode: 1 })
+  })
+
   it('propagates error when openDatabase throws', async () => {
     openDatabaseMock.mockImplementation(() => {
       throw new Error('DB error')

--- a/src/commands/budget/set.ts
+++ b/src/commands/budget/set.ts
@@ -187,8 +187,11 @@ async function setAction(
 
 export function createSetBudgetCommand(defaultDb: string): Command {
   return new Command('set')
-    .description('Set a monthly budget for a top-level category')
-    .argument('[category]', 'category slug (e.g. necessities, discretionary, savings) — prompts if omitted')
+    .description('Set a monthly budget for a budgetable top-level category')
+    .argument(
+      '[category]',
+      'budgetable category slug (e.g. necessities, discretionary, savings) — prompts if omitted',
+    )
     .argument('[amount]', 'budget amount in EUR (e.g. 2000) or percentage of income (e.g. 60%) — prompts if omitted')
     .option('-m, --month <YYYY-MM>', 'target month (defaults to current)')
     .option('-d, --db <path>', 'SQLite database path', defaultDb)

--- a/src/commands/budget/set.ts
+++ b/src/commands/budget/set.ts
@@ -188,10 +188,7 @@ async function setAction(
 export function createSetBudgetCommand(defaultDb: string): Command {
   return new Command('set')
     .description('Set a monthly budget for a budgetable top-level category')
-    .argument(
-      '[category]',
-      'budgetable category slug (e.g. necessities, discretionary, savings) — prompts if omitted',
-    )
+    .argument('[category]', 'budgetable category slug (e.g. necessities, discretionary, savings) — prompts if omitted')
     .argument('[amount]', 'budget amount in EUR (e.g. 2000) or percentage of income (e.g. 60%) — prompts if omitted')
     .option('-m, --month <YYYY-MM>', 'target month (defaults to current)')
     .option('-d, --db <path>', 'SQLite database path', defaultDb)

--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -20,6 +20,12 @@ export const CATEGORIES: Category[] = [
     slug: 'discretionary',
     parentId: null,
   },
+  {
+    id: '3f9e4c2a-6b7d-4a8f-9c1e-2d3f4a5b6c7d',
+    name: 'Transfers',
+    slug: 'transfers',
+    parentId: null,
+  },
 
   // L2 under Necessities
   {
@@ -201,6 +207,20 @@ export const CATEGORIES: Category[] = [
     name: 'Restaurant',
     slug: 'restaurant',
     parentId: 'c2d3e4f5-6a7b-4c8d-9e0f-1a2b3c4d5e6f',
+  },
+  {
+    id: 'cc6f9a0b-1d2e-4c3f-8a9b-0c1d2e3f4a5b',
+    name: 'Coffee',
+    slug: 'coffee',
+    parentId: 'c2d3e4f5-6a7b-4c8d-9e0f-1a2b3c4d5e6f',
+  },
+
+  // L2 under Transfers
+  {
+    id: '4a0f5d3b-7c8e-4b90-a1d2-3e4f5a6b7c8d',
+    name: 'Internal Transfer',
+    slug: 'internal-transfer',
+    parentId: '3f9e4c2a-6b7d-4a8f-9c1e-2d3f4a5b6c7d',
   },
 
   // Root

--- a/src/db/categories/queries.test.ts
+++ b/src/db/categories/queries.test.ts
@@ -50,6 +50,15 @@ describe('collectDescendantIds', () => {
     expect(ids).toContain(restaurant.id)
   })
 
+  it('includes transfer children', () => {
+    const transfers = CATEGORIES.find((category) => category.slug === 'transfers')!
+    const internalTransfer = CATEGORIES.find((category) => category.slug === 'internal-transfer')!
+
+    const ids = collectDescendantIds(CATEGORIES, transfers.id)
+
+    expect(ids).toContain(internalTransfer.id)
+  })
+
   it('does not include unrelated categories', () => {
     const savings = CATEGORIES.find((category) => category.slug === 'savings')!
     const groceries = CATEGORIES.find((category) => category.slug === 'groceries')!


### PR DESCRIPTION
## Summary
- add Transfers/Internal Transfer categories for account-to-account movement
- add Coffee under Food & Drink
- exclude Transfers from budget setup while keeping it available for classification/reporting

## Tests
- bun test