### PR TITLE
feat: add npm publishing and GitHub Release assets

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr: ${{ steps.release.outputs.pr }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - id: release
         uses: googleapis/release-please-action@v4
@@ -47,3 +49,52 @@ jobs:
           git add CHANGELOG.md
           git diff --staged --quiet || git commit -m "chore: format changelog"
           git push
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  upload-assets:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Upload bundle to release
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/flouz --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -155,3 +155,25 @@ jobs:
             [ -f /tmp/test-output.txt ] && sed -e 's/\x1B\[[0-9;]*[a-zA-Z]//g' -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' /tmp/test-output.txt >> $GITHUB_STEP_SUMMARY
             echo "</pre></details>" >> $GITHUB_STEP_SUMMARY
           fi
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build bundle
+        run: bun run build
+
+      - name: Verify bundle exists
+        run: test -f dist/flouz && echo "Bundle built successfully ($(du -h dist/flouz | cut -f1))"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "flouz",
+  "name": "@lfarci/flouz",
   "version": "2.4.0",
   "description": "AI-powered personal finance CLI for analyzing bank transactions",
   "license": "MIT",
@@ -17,10 +17,12 @@
   ],
   "module": "src/index.ts",
   "type": "module",
-  "private": true,
   "bin": {
-    "flouz": "./src/index.ts"
+    "flouz": "dist/flouz"
   },
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun --watch src/index.ts",
@@ -31,7 +33,8 @@
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "test:coverage": "bun test --coverage",
-    "build": "bun build src/index.ts --outfile dist/flouz --target bun"
+    "build": "bun build src/index.ts --outfile dist/flouz --target bun",
+    "prepublishOnly": "bun run build"
   },
   "devDependencies": {
     "@eslint/js": "9",


### PR DESCRIPTION
When release-please creates a new version, the release workflow now builds the Bun JS bundle and distributes it through two channels:

1. **npm** -- published as `@lfarci/flouz` so users can install with `bun add -g @lfarci/flouz`
2. **GitHub Releases** -- the built bundle (~1.6 MB) is attached as a downloadable asset

## Approach

- Renamed the package to `@lfarci/flouz` and removed the `private` flag so npm publish works
- `bin` now points to `dist/flouz` (the bundled output) instead of raw TypeScript
- Added `files: ["dist/"]` so only the built artifact ships to npm
- Extended the release-please workflow with `publish-npm` (with provenance) and `upload-assets` jobs
- Added a `build` job to `run-checks.yml` so PRs catch build failures before merge

## Setup required after merge

Before the first release can publish successfully:

1. Create the `@lfarci` scope on npmjs.com (or ensure it exists)
2. Generate an npm automation access token
3. Add it as the `NPM_TOKEN` repository secret in GitHub Settings > Secrets

## Notes

- Bundle is ~1.6 MB with the shebang preserved -- users need Bun installed to run it
- No compiled standalone binaries (those would be ~97 MB each per platform)
- `dist/` remains gitignored; only CI produces the artifact