### PR TITLE
Add account balance tracking

### DIFF
--- a/src/commands/accounts/README.md
+++ b/src/commands/accounts/README.md
@@ -5,10 +5,22 @@
 The `accounts` command manages configured accounts used during transaction import.
 
 - `add` creates an account with a unique machine key and a human-readable name
+- `snapshot` saves an authoritative end-of-day balance for an account
+- `balance` shows a derived balance for an account on a date
+- `history` shows daily derived balances from snapshots and transactions
 - `delete` removes an account by key when no transactions reference it
 - `list` prints configured accounts so import keys are visible before running `flouz import`
 
 ## Scope
 
-This command is responsible for account registry management only.
-It stores account metadata in the database so imported transactions can reference accounts by foreign key.
+This command stores account metadata and account balance snapshots.
+Snapshots are authoritative end-of-day balances. Balance history is derived by applying same-account transactions around the closest snapshot.
+Transactions without an account are not included in account balance calculations.
+
+## Examples
+
+```bash
+flouz accounts snapshot checking 1250.00 --date 2026-06-04
+flouz accounts balance checking --date 2026-06-04
+flouz accounts history checking --from 2026-06-01 --to 2026-06-30
+```

--- a/src/commands/accounts/balance-input.ts
+++ b/src/commands/accounts/balance-input.ts
@@ -1,0 +1,54 @@
+import { type Database } from 'bun:sqlite'
+import { getAccountByKey } from '@/db/accounts/queries'
+import { normalizeAccountKey } from '@/db/accounts/mutations'
+import { currentCalendarDate, requireCalendarDate, requireDateRange } from '@/db/account_balance_snapshots/date'
+import type { Account } from '@/types'
+
+const BALANCE_AMOUNT_PATTERN = /^-?\d+(?:\.\d+)?$/
+const CURRENCY_PATTERN = /^[A-Z]{3}$/
+
+export function parseBalanceAmount(value: string): number {
+  const trimmedValue = value.trim()
+  if (!BALANCE_AMOUNT_PATTERN.test(trimmedValue)) {
+    throw new Error(`Invalid amount: "${value}". Use a decimal number.`)
+  }
+
+  return Number.parseFloat(trimmedValue)
+}
+
+export function normalizeCurrency(value: string | undefined): string {
+  const currency = value?.trim() ?? 'EUR'
+  if (CURRENCY_PATTERN.test(currency)) return currency
+  throw new Error(`Invalid currency: "${value}". Use a 3-letter uppercase code.`)
+}
+
+export function normalizeOptionalText(value: string | undefined): string | undefined {
+  const normalizedValue = value?.trim()
+  if (normalizedValue === undefined || normalizedValue.length === 0) return undefined
+  return normalizedValue
+}
+
+export function resolveDateOption(value: string | undefined): string {
+  return requireCalendarDate(value ?? currentCalendarDate(), 'date')
+}
+
+export function resolveDateRangeOptions(
+  fromValue: string | undefined,
+  toValue: string | undefined,
+): { from: string; to: string } {
+  const to = requireCalendarDate(toValue ?? currentCalendarDate(), 'to date')
+  const from = requireCalendarDate(fromValue ?? to, 'from date')
+  requireDateRange(from, to)
+  return { from, to }
+}
+
+export function requireAccount(database: Database, key: string): Account {
+  const normalizedKey = normalizeAccountKey(key)
+  if (normalizedKey.length === 0) {
+    throw new Error('Account key cannot be empty')
+  }
+
+  const account = getAccountByKey(database, normalizedKey)
+  if (account !== undefined) return account
+  throw new Error(`Unknown account key: ${normalizedKey}`)
+}

--- a/src/commands/accounts/balance-output.ts
+++ b/src/commands/accounts/balance-output.ts
@@ -1,0 +1,55 @@
+import { renderCliTable } from '@/cli/table'
+import type { BalanceHistoryPoint, DerivedAccountBalance } from '@/types'
+import { escapeCsvField } from '@/commands/transactions/format'
+
+export type BalanceHistoryRow = {
+  account: string
+  date: string
+  amount: string
+  snapshotDate: string
+  direction: string
+}
+
+export function formatAmountWithCurrency(amount: number, currency: string): string {
+  return `${amount.toFixed(2)} ${currency}`
+}
+
+export function formatDerivedBalance(accountKey: string, balance: DerivedAccountBalance): string {
+  const amount = formatAmountWithCurrency(balance.amount, balance.currency)
+  return `${accountKey} balance on ${balance.date}: ${amount} (snapshot ${balance.snapshotDate})`
+}
+
+export function toBalanceHistoryRow(accountKey: string, point: BalanceHistoryPoint): BalanceHistoryRow {
+  return {
+    account: accountKey,
+    date: point.date,
+    amount: formatAmountWithCurrency(point.amount, point.currency),
+    snapshotDate: point.snapshotDate,
+    direction: point.direction,
+  }
+}
+
+export function formatBalanceHistoryTable(rows: BalanceHistoryRow[]): string[] {
+  return renderCliTable({
+    columns: [
+      { header: 'Account', width: 18, minWidth: 12, truncate: 18 },
+      { header: 'Date', width: 10, minWidth: 10, truncate: 10 },
+      { header: 'Balance', width: 14, minWidth: 12, alignment: 'right' },
+      { header: 'Snapshot', width: 10, minWidth: 10, truncate: 10 },
+      { header: 'Mode', width: 8, minWidth: 7, truncate: 8 },
+    ],
+    rows: rows.map((row) => [row.account, row.date, row.amount, row.snapshotDate, row.direction]),
+  })
+}
+
+export function buildBalanceHistoryCsv(rows: BalanceHistoryRow[]): string {
+  const header = 'account,date,amount,snapshotDate,direction'
+  const dataRows = rows.map((row) =>
+    [row.account, row.date, row.amount, row.snapshotDate, row.direction].map(escapeCsvField).join(','),
+  )
+  return [header, ...dataRows].join('\n')
+}
+
+export function buildBalanceHistoryJson(rows: BalanceHistoryRow[]): string {
+  return JSON.stringify(rows, undefined, 2)
+}

--- a/src/commands/accounts/balance.test.ts
+++ b/src/commands/accounts/balance.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import {
+  collectCommandOutcome,
+  createCommandTestDatabase,
+  createOpenDatabaseMock,
+  createProcessExitMock,
+  getArgumentSetup,
+  restoreProcessExit,
+  runCommandSilently,
+  setProcessExit,
+} from '@/commands/test-helpers'
+import { insertAccount } from '@/db/accounts/mutations'
+import { createAccountsTable } from '@/db/accounts/schema'
+import { upsertAccountBalanceSnapshot } from '@/db/account_balance_snapshots/mutations'
+import { createAccountBalanceSnapshotsTable } from '@/db/account_balance_snapshots/schema'
+import { insertTransaction } from '@/db/transactions/mutations'
+import { createTransactionsTable } from '@/db/transactions/schema'
+import type { createBalanceAccountsCommand as CreateBalanceAccountsCommand } from './balance'
+
+const infoLogMock = mock((message: string) => message)
+const errorLogMock = mock((message: string) => message)
+const openDatabaseMock = createOpenDatabaseMock()
+
+void mock.module('@clack/prompts', () => ({
+  log: {
+    info: infoLogMock,
+    error: errorLogMock,
+  },
+}))
+
+void mock.module('@/db/schema', () => ({
+  openDatabase: (dbPath: string) => openDatabaseMock(dbPath),
+}))
+
+type BalanceSummary = {
+  status: 'resolved' | 'rejected'
+  errorCode?: number
+}
+
+let createBalanceAccountsCommand: typeof CreateBalanceAccountsCommand
+let originalProcessExit: typeof process.exit
+const processExitMock = createProcessExitMock()
+
+function createInMemoryDatabase() {
+  return createCommandTestDatabase((database) => {
+    createAccountsTable(database)
+    createAccountBalanceSnapshotsTable(database)
+    createTransactionsTable(database)
+  })
+}
+
+async function runBalanceCommand(argumentsList: string[]): Promise<void> {
+  await runCommandSilently(createBalanceAccountsCommand('default.db'), argumentsList)
+}
+
+async function collectBalanceOutcome(argumentsList: string[]): Promise<BalanceSummary> {
+  return await collectCommandOutcome<BalanceSummary>(
+    () => runBalanceCommand(argumentsList),
+    () => ({ status: 'resolved' }),
+    (errorCode) => ({ status: 'rejected', errorCode }),
+  )
+}
+
+beforeAll(async () => {
+  originalProcessExit = process.exit
+  ;({ createBalanceAccountsCommand } = await import('./balance'))
+})
+
+beforeEach(() => {
+  infoLogMock.mockClear()
+  errorLogMock.mockClear()
+  openDatabaseMock.mockReset()
+  processExitMock.mockClear()
+  originalProcessExit = setProcessExit(processExitMock)
+})
+
+afterEach(() => {
+  restoreProcessExit(originalProcessExit)
+})
+
+describe('createBalanceAccountsCommand', () => {
+  it('creates the balance command', () => {
+    const command = createBalanceAccountsCommand('flouz.db')
+
+    expect(command.name()).toBe('balance')
+  })
+
+  it('registers the key argument', () => {
+    const command = createBalanceAccountsCommand('flouz.db')
+
+    expect(getArgumentSetup(command, 0)).toEqual({
+      name: 'key',
+      required: true,
+      description: 'account key',
+      variadic: false,
+    })
+  })
+})
+
+describe('balanceAccountAction', () => {
+  it('prints a derived account balance', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    const accountId = insertAccount(database, {
+      key: 'checking',
+      company: 'Provider One',
+      name: 'Main account',
+    })
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-01',
+      amount: 1000,
+      currency: 'EUR',
+    })
+    insertTransaction(database, {
+      date: '2026-06-02',
+      amount: -25,
+      counterparty: 'ACME Shop',
+      currency: 'EUR',
+      accountId,
+      importedAt: '2026-06-04T00:00:00.000Z',
+    })
+    openDatabaseMock.mockReturnValue(handle)
+
+    const summary = await collectBalanceOutcome(['checking', '--date', '2026-06-02'])
+
+    expect({
+      summary,
+      messages: infoLogMock.mock.calls.map((call) => call[0]),
+    }).toEqual({
+      summary: { status: 'resolved' },
+      messages: ['checking balance on 2026-06-02: 975.00 EUR (snapshot 2026-06-01)'],
+    })
+  })
+
+  it('fails clearly when no snapshot exists', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertAccount(database, {
+      key: 'checking',
+      company: 'Provider One',
+      name: 'Main account',
+    })
+    openDatabaseMock.mockReturnValue(handle)
+
+    const summary = await collectBalanceOutcome(['checking', '--date', '2026-06-02'])
+
+    expect({
+      summary,
+      errors: errorLogMock.mock.calls.map((call) => call[0]),
+    }).toEqual({
+      summary: { status: 'rejected', errorCode: 1 },
+      errors: ['No balance snapshot found for account 1'],
+    })
+  })
+})

--- a/src/commands/accounts/balance.ts
+++ b/src/commands/accounts/balance.ts
@@ -1,0 +1,39 @@
+import { log } from '@clack/prompts'
+import { type Database } from 'bun:sqlite'
+import { Command } from 'commander'
+import { resolve } from 'node:path'
+import { formatDerivedBalance } from '@/commands/accounts/balance-output'
+import { requireAccount, resolveDateOption } from '@/commands/accounts/balance-input'
+import { getDerivedAccountBalance } from '@/db/account_balance_snapshots/derived'
+import { openDatabase } from '@/db/schema'
+
+type BalanceOptions = {
+  date?: string
+  db: string
+}
+
+function balanceAccountAction(key: string, options: BalanceOptions): void {
+  let database: Database | undefined
+
+  try {
+    const date = resolveDateOption(options.date)
+    database = openDatabase(resolve(options.db))
+    const account = requireAccount(database, key)
+    const balance = getDerivedAccountBalance(database, account.id, date)
+    log.info(formatDerivedBalance(account.key, balance))
+  } catch (error) {
+    log.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  } finally {
+    database?.close()
+  }
+}
+
+export function createBalanceAccountsCommand(defaultDb: string): Command {
+  return new Command('balance')
+    .description('Show an account balance for a date')
+    .argument('<key>', 'account key')
+    .option('--date <YYYY-MM-DD>', 'balance date (defaults to today)')
+    .option('--db <path>', 'SQLite database path', defaultDb)
+    .action(balanceAccountAction)
+}

--- a/src/commands/accounts/delete.test.ts
+++ b/src/commands/accounts/delete.test.ts
@@ -15,6 +15,8 @@ import {
 import { insertAccount } from '@/db/accounts/mutations'
 import { countAccounts, getAccountByKey } from '@/db/accounts/queries'
 import { createAccountsTable } from '@/db/accounts/schema'
+import { upsertAccountBalanceSnapshot } from '@/db/account_balance_snapshots/mutations'
+import { createAccountBalanceSnapshotsTable } from '@/db/account_balance_snapshots/schema'
 import { createCategoriesTable } from '@/db/categories/schema'
 import { createTransactionsTable } from '@/db/transactions/schema'
 import { insertTransaction } from '@/db/transactions/mutations'
@@ -78,6 +80,7 @@ function createInMemoryDatabase() {
   return createCommandTestDatabase((database) => {
     createCategoriesTable(database)
     createAccountsTable(database)
+    createAccountBalanceSnapshotsTable(database)
     createTransactionsTable(database)
   })
 }
@@ -267,6 +270,44 @@ describe('deleteAccountAction', () => {
         accountCount: 0,
       },
       successMessages: ['Deleted account checking'],
+      closeCalls: 1,
+    })
+  })
+
+  it('rejects deleting an account with balance snapshots', async () => {
+    const { database, handle, closeMock } = createInMemoryDatabase()
+    openDatabaseMock.mockReturnValue(handle)
+    const accountId = insertAccount(database, {
+      key: 'checking',
+      company: 'Provider One',
+      name: 'Main account',
+    })
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-04',
+      amount: 1250,
+      currency: 'EUR',
+    })
+
+    const summary = await collectDeleteCommandOutcome(database, ['checking'], 'checking')
+
+    expect({
+      summary,
+      errorMessages: getLoggedMessages(errorLogMock),
+      closeCalls: closeMock.mock.calls.length,
+    }).toEqual({
+      summary: {
+        status: 'rejected',
+        errorCode: 1,
+        account: {
+          id: 1,
+          key: 'checking',
+          company: 'Provider One',
+          name: 'Main account',
+        },
+        accountCount: 1,
+      },
+      errorMessages: ['Cannot delete account checking: it has balance snapshots.'],
       closeCalls: 1,
     })
   })

--- a/src/commands/accounts/delete.ts
+++ b/src/commands/accounts/delete.ts
@@ -1,6 +1,7 @@
 import { log } from '@clack/prompts'
 import { Command } from 'commander'
 import { resolve } from 'node:path'
+import { hasBalanceSnapshotsForAccount } from '@/db/account_balance_snapshots/queries'
 import { deleteAccountByKey } from '@/db/accounts/mutations'
 import { getAccountByKey } from '@/db/accounts/queries'
 import { openDatabase } from '@/db/schema'
@@ -33,6 +34,10 @@ function deleteAccountAction(key: string, options: DeleteAccountOptions): void {
 
     if (hasTransactionsForAccount(database, account.id)) {
       throw new Error(`Cannot delete account ${normalizedKey}: it is referenced by transactions.`)
+    }
+
+    if (hasBalanceSnapshotsForAccount(database, account.id)) {
+      throw new Error(`Cannot delete account ${normalizedKey}: it has balance snapshots.`)
     }
 
     deleteAccountByKey(database, normalizedKey)

--- a/src/commands/accounts/history.test.ts
+++ b/src/commands/accounts/history.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import {
+  collectCommandOutcome,
+  createCommandTestDatabase,
+  createOpenDatabaseMock,
+  createProcessExitMock,
+  getArgumentSetup,
+  restoreProcessExit,
+  runCommandSilently,
+  setProcessExit,
+} from '@/commands/test-helpers'
+import { insertAccount } from '@/db/accounts/mutations'
+import { createAccountsTable } from '@/db/accounts/schema'
+import { upsertAccountBalanceSnapshot } from '@/db/account_balance_snapshots/mutations'
+import { createAccountBalanceSnapshotsTable } from '@/db/account_balance_snapshots/schema'
+import { insertTransaction } from '@/db/transactions/mutations'
+import { createTransactionsTable } from '@/db/transactions/schema'
+import type {
+  createHistoryAccountsCommand as CreateHistoryAccountsCommand,
+  parseHistoryOutputFormat as ParseHistoryOutputFormat,
+} from './history'
+
+const messageLogMock = mock((message: string[] | string, options?: { spacing?: number; withGuide?: boolean }) => ({
+  message,
+  options,
+}))
+const infoLogMock = mock((message: string) => message)
+const errorLogMock = mock((message: string) => message)
+const openDatabaseMock = createOpenDatabaseMock()
+
+void mock.module('@clack/prompts', () => ({
+  log: {
+    message: messageLogMock,
+    info: infoLogMock,
+    error: errorLogMock,
+  },
+}))
+
+void mock.module('@/db/schema', () => ({
+  openDatabase: (dbPath: string) => openDatabaseMock(dbPath),
+}))
+
+type HistorySummary = {
+  status: 'resolved' | 'rejected'
+  errorCode?: number
+}
+
+let createHistoryAccountsCommand: typeof CreateHistoryAccountsCommand
+let parseHistoryOutputFormat: typeof ParseHistoryOutputFormat
+let originalProcessExit: typeof process.exit
+const processExitMock = createProcessExitMock()
+
+function createInMemoryDatabase() {
+  return createCommandTestDatabase((database) => {
+    createAccountsTable(database)
+    createAccountBalanceSnapshotsTable(database)
+    createTransactionsTable(database)
+  })
+}
+
+async function runHistoryCommand(argumentsList: string[]): Promise<void> {
+  await runCommandSilently(createHistoryAccountsCommand('default.db'), argumentsList)
+}
+
+async function collectHistoryOutcome(argumentsList: string[]): Promise<HistorySummary> {
+  return await collectCommandOutcome<HistorySummary>(
+    () => runHistoryCommand(argumentsList),
+    () => ({ status: 'resolved' }),
+    (errorCode) => ({ status: 'rejected', errorCode }),
+  )
+}
+
+beforeAll(async () => {
+  originalProcessExit = process.exit
+  ;({ createHistoryAccountsCommand, parseHistoryOutputFormat } = await import('./history'))
+})
+
+beforeEach(() => {
+  messageLogMock.mockClear()
+  infoLogMock.mockClear()
+  errorLogMock.mockClear()
+  openDatabaseMock.mockReset()
+  processExitMock.mockClear()
+  originalProcessExit = setProcessExit(processExitMock)
+})
+
+afterEach(() => {
+  restoreProcessExit(originalProcessExit)
+})
+
+describe('createHistoryAccountsCommand', () => {
+  it('creates the history command with an optional key argument', () => {
+    const command = createHistoryAccountsCommand('flouz.db')
+
+    expect({
+      name: command.name(),
+      argument: getArgumentSetup(command, 0),
+    }).toEqual({
+      name: 'history',
+      argument: {
+        name: 'key',
+        required: false,
+        description: 'account key',
+        variadic: false,
+      },
+    })
+  })
+
+  it('parses supported output formats', () => {
+    expect(['table', 'csv', 'json'].map(parseHistoryOutputFormat)).toEqual(['table', 'csv', 'json'])
+  })
+})
+
+describe('historyAccountAction', () => {
+  it('prints daily derived balance history for one account', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    const accountId = insertAccount(database, {
+      key: 'checking',
+      company: 'Provider One',
+      name: 'Main account',
+    })
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-01',
+      amount: 1000,
+      currency: 'EUR',
+    })
+    insertTransaction(database, {
+      date: '2026-06-02',
+      amount: -25,
+      counterparty: 'ACME Shop',
+      currency: 'EUR',
+      accountId,
+      importedAt: '2026-06-04T00:00:00.000Z',
+    })
+    openDatabaseMock.mockReturnValue(handle)
+
+    const summary = await collectHistoryOutcome(['checking', '--from', '2026-06-01', '--to', '2026-06-02'])
+    const tableText = (messageLogMock.mock.calls[0][0] as string[]).join('\n')
+
+    expect({
+      summary,
+      hasChecking: tableText.includes('checking'),
+      hasDerivedBalance: tableText.includes('975.00 EUR'),
+    }).toEqual({
+      summary: { status: 'resolved' },
+      hasChecking: true,
+      hasDerivedBalance: true,
+    })
+  })
+
+  it('rejects an invalid date range', async () => {
+    const { handle } = createInMemoryDatabase()
+    openDatabaseMock.mockReturnValue(handle)
+
+    const summary = await collectHistoryOutcome(['--from', '2026-06-03', '--to', '2026-06-01'])
+
+    expect(summary).toEqual({ status: 'rejected', errorCode: 1 })
+  })
+})

--- a/src/commands/accounts/history.ts
+++ b/src/commands/accounts/history.ts
@@ -1,0 +1,102 @@
+import { emptyState } from '@/cli/empty'
+import { isBrokenPipeError, writeStdout } from '@/cli/stdout'
+import { log } from '@clack/prompts'
+import { type Database } from 'bun:sqlite'
+import { Command } from 'commander'
+import { resolve } from 'node:path'
+import {
+  buildBalanceHistoryCsv,
+  buildBalanceHistoryJson,
+  formatBalanceHistoryTable,
+  toBalanceHistoryRow,
+  type BalanceHistoryRow,
+} from '@/commands/accounts/balance-output'
+import { requireAccount, resolveDateRangeOptions } from '@/commands/accounts/balance-input'
+import { getAccounts } from '@/db/accounts/queries'
+import { getBalanceHistory } from '@/db/account_balance_snapshots/derived'
+import { getBalanceSnapshots } from '@/db/account_balance_snapshots/queries'
+import { openDatabase } from '@/db/schema'
+import type { Account } from '@/types'
+
+type OutputFormat = 'table' | 'csv' | 'json'
+
+type HistoryOptions = {
+  from?: string
+  to?: string
+  output: OutputFormat
+  db: string
+}
+
+export function parseHistoryOutputFormat(value: string): OutputFormat {
+  if (value === 'table' || value === 'csv' || value === 'json') return value
+  throw new Error(`Invalid output format: ${value}. Use table, csv, or json.`)
+}
+
+async function historyAccountAction(key: string | undefined, options: HistoryOptions): Promise<void> {
+  let database: Database | undefined
+
+  try {
+    const range = resolveDateRangeOptions(options.from, options.to)
+    database = openDatabase(resolve(options.db))
+    const accounts = resolveHistoryAccounts(database, key)
+    const rows = buildHistoryRows(database, accounts, range)
+    await writeHistoryRows(rows, options.output)
+  } catch (error) {
+    if (isBrokenPipeError(error)) {
+      process.exit(0)
+    }
+
+    log.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  } finally {
+    database?.close()
+  }
+}
+
+function resolveHistoryAccounts(database: Database, key: string | undefined): Account[] {
+  if (key !== undefined) return [requireAccount(database, key)]
+
+  return getAccounts(database).filter((account) => {
+    return getBalanceSnapshots(database, { accountId: account.id }).length > 0
+  })
+}
+
+function buildHistoryRows(
+  database: Database,
+  accounts: Account[],
+  range: { from: string; to: string },
+): BalanceHistoryRow[] {
+  return accounts.flatMap((account) => {
+    const points = getBalanceHistory(database, { accountId: account.id, from: range.from, to: range.to })
+    return points.map((point) => toBalanceHistoryRow(account.key, point))
+  })
+}
+
+async function writeHistoryRows(rows: BalanceHistoryRow[], outputFormat: OutputFormat): Promise<void> {
+  if (rows.length === 0 && outputFormat === 'table') {
+    emptyState('No balance snapshots found.', 'Run `flouz accounts snapshot` to save an account balance.')
+    return
+  }
+
+  if (outputFormat === 'csv') {
+    await writeStdout(`${buildBalanceHistoryCsv(rows)}\n`)
+    return
+  }
+  if (outputFormat === 'json') {
+    await writeStdout(`${buildBalanceHistoryJson(rows)}\n`)
+    return
+  }
+
+  log.message(formatBalanceHistoryTable(rows), { spacing: 0, withGuide: false })
+}
+
+export function createHistoryAccountsCommand(defaultDb: string): Command {
+  return new Command('history')
+    .description('Show account balance history')
+    .argument('[key]', 'account key')
+    .option('--from <YYYY-MM-DD>', 'start date (defaults to --to)')
+    .option('--to <YYYY-MM-DD>', 'end date (defaults to today)')
+    .option('-o, --output <format>', 'output format (table, csv, json)', parseHistoryOutputFormat, 'table')
+    .option('--db <path>', 'SQLite database path', defaultDb)
+    .action(historyAccountAction)
+}

--- a/src/commands/accounts/index.test.ts
+++ b/src/commands/accounts/index.test.ts
@@ -7,6 +7,6 @@ describe('createAccountsCommand', () => {
     const command = await createAccountsCommand()
     const subcommandNames = command.commands.map((subcommand) => subcommand.name())
 
-    expect(subcommandNames).toEqual(['add', 'delete', 'list'])
+    expect(subcommandNames).toEqual(['add', 'snapshot', 'balance', 'history', 'delete', 'list'])
   })
 })

--- a/src/commands/accounts/index.ts
+++ b/src/commands/accounts/index.ts
@@ -1,14 +1,20 @@
 import { Command } from 'commander'
 import { resolveDbPath } from '@/config'
 import { createAddAccountsCommand } from './add'
+import { createBalanceAccountsCommand } from './balance'
 import { createDeleteAccountsCommand } from './delete'
+import { createHistoryAccountsCommand } from './history'
 import { createListAccountsCommand } from './list'
+import { createSnapshotAccountsCommand } from './snapshot'
 
 export async function createAccountsCommand(): Promise<Command> {
   const defaultDb = await resolveDbPath()
   return new Command('accounts')
     .description('Manage configured accounts')
     .addCommand(createAddAccountsCommand(defaultDb))
+    .addCommand(createSnapshotAccountsCommand(defaultDb))
+    .addCommand(createBalanceAccountsCommand(defaultDb))
+    .addCommand(createHistoryAccountsCommand(defaultDb))
     .addCommand(createDeleteAccountsCommand(defaultDb))
     .addCommand(createListAccountsCommand(defaultDb))
 }

--- a/src/commands/accounts/snapshot.test.ts
+++ b/src/commands/accounts/snapshot.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { type Database } from 'bun:sqlite'
+import {
+  collectCommandOutcome,
+  createCommandTestDatabase,
+  createOpenDatabaseMock,
+  createProcessExitMock,
+  getArgumentSetup,
+  restoreProcessExit,
+  runCommandSilently,
+  setProcessExit,
+} from '@/commands/test-helpers'
+import { insertAccount } from '@/db/accounts/mutations'
+import { createAccountsTable } from '@/db/accounts/schema'
+import { getBalanceSnapshotForDate } from '@/db/account_balance_snapshots/queries'
+import { createAccountBalanceSnapshotsTable } from '@/db/account_balance_snapshots/schema'
+import type { AccountBalanceSnapshot } from '@/types'
+import type { createSnapshotAccountsCommand as CreateSnapshotAccountsCommand } from './snapshot'
+
+const successLogMock = mock((message: string) => message)
+const errorLogMock = mock((message: string) => message)
+const openDatabaseMock = createOpenDatabaseMock()
+
+void mock.module('@clack/prompts', () => ({
+  log: {
+    success: successLogMock,
+    error: errorLogMock,
+  },
+}))
+
+void mock.module('@/db/schema', () => ({
+  openDatabase: (dbPath: string) => openDatabaseMock(dbPath),
+}))
+
+type SnapshotSummary = {
+  status: 'resolved' | 'rejected'
+  errorCode?: number
+  snapshot?: AccountBalanceSnapshot
+}
+
+let createSnapshotAccountsCommand: typeof CreateSnapshotAccountsCommand
+let originalProcessExit: typeof process.exit
+const processExitMock = createProcessExitMock()
+
+function createInMemoryDatabase() {
+  return createCommandTestDatabase((database) => {
+    createAccountsTable(database)
+    createAccountBalanceSnapshotsTable(database)
+  })
+}
+
+async function runSnapshotCommand(argumentsList: string[]): Promise<void> {
+  await runCommandSilently(createSnapshotAccountsCommand('default.db'), argumentsList)
+}
+
+async function collectSnapshotOutcome(database: Database, argumentsList: string[]): Promise<SnapshotSummary> {
+  return await collectCommandOutcome<SnapshotSummary>(
+    () => runSnapshotCommand(argumentsList),
+    () => ({
+      status: 'resolved',
+      snapshot: getBalanceSnapshotForDate(database, 1, '2026-06-04'),
+    }),
+    (errorCode) => ({
+      status: 'rejected',
+      errorCode,
+      snapshot: getBalanceSnapshotForDate(database, 1, '2026-06-04'),
+    }),
+  )
+}
+
+beforeAll(async () => {
+  originalProcessExit = process.exit
+  ;({ createSnapshotAccountsCommand } = await import('./snapshot'))
+})
+
+beforeEach(() => {
+  successLogMock.mockClear()
+  errorLogMock.mockClear()
+  openDatabaseMock.mockReset()
+  processExitMock.mockClear()
+  originalProcessExit = setProcessExit(processExitMock)
+})
+
+afterEach(() => {
+  restoreProcessExit(originalProcessExit)
+})
+
+describe('createSnapshotAccountsCommand', () => {
+  it('creates the snapshot command', () => {
+    const command = createSnapshotAccountsCommand('flouz.db')
+
+    expect(command.name()).toBe('snapshot')
+  })
+
+  it('registers key and amount arguments', () => {
+    const command = createSnapshotAccountsCommand('flouz.db')
+
+    expect([getArgumentSetup(command, 0), getArgumentSetup(command, 1)]).toEqual([
+      {
+        name: 'key',
+        required: true,
+        description: 'account key',
+        variadic: false,
+      },
+      {
+        name: 'amount',
+        required: true,
+        description: 'account balance amount',
+        variadic: false,
+      },
+    ])
+  })
+})
+
+describe('snapshotAccountAction', () => {
+  it('saves a balance snapshot for an existing account', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertAccount(database, {
+      key: 'checking',
+      company: 'Provider One',
+      name: 'Main account',
+    })
+    openDatabaseMock.mockReturnValue(handle)
+
+    const summary = await collectSnapshotOutcome(database, [
+      'checking',
+      '1250.50',
+      '--date',
+      '2026-06-04',
+      '--note',
+      ' Statement balance ',
+    ])
+
+    expect(summary).toMatchObject({
+      status: 'resolved',
+      snapshot: {
+        accountId: 1,
+        date: '2026-06-04',
+        amount: 1250.5,
+        currency: 'EUR',
+        note: 'Statement balance',
+      },
+    })
+  })
+
+  it('rejects an invalid amount before saving', async () => {
+    const { database, handle } = createInMemoryDatabase()
+    insertAccount(database, {
+      key: 'checking',
+      company: 'Provider One',
+      name: 'Main account',
+    })
+    openDatabaseMock.mockReturnValue(handle)
+
+    const summary = await collectSnapshotOutcome(database, ['checking', 'abc', '--date', '2026-06-04'])
+
+    expect(summary).toEqual({
+      status: 'rejected',
+      errorCode: 1,
+      snapshot: undefined,
+    })
+  })
+})

--- a/src/commands/accounts/snapshot.ts
+++ b/src/commands/accounts/snapshot.ts
@@ -1,0 +1,59 @@
+import { log } from '@clack/prompts'
+import { type Database } from 'bun:sqlite'
+import { Command } from 'commander'
+import { resolve } from 'node:path'
+import { formatAmountWithCurrency } from '@/commands/accounts/balance-output'
+import {
+  normalizeCurrency,
+  normalizeOptionalText,
+  parseBalanceAmount,
+  requireAccount,
+  resolveDateOption,
+} from '@/commands/accounts/balance-input'
+import { upsertAccountBalanceSnapshot } from '@/db/account_balance_snapshots/mutations'
+import { openDatabase } from '@/db/schema'
+
+type SnapshotOptions = {
+  date?: string
+  currency?: string
+  note?: string
+  db: string
+}
+
+function snapshotAccountAction(key: string, amountValue: string, options: SnapshotOptions): void {
+  let database: Database | undefined
+
+  try {
+    const date = resolveDateOption(options.date)
+    const amount = parseBalanceAmount(amountValue)
+    const currency = normalizeCurrency(options.currency)
+    database = openDatabase(resolve(options.db))
+    const account = requireAccount(database, key)
+
+    upsertAccountBalanceSnapshot(database, {
+      accountId: account.id,
+      date,
+      amount,
+      currency,
+      note: normalizeOptionalText(options.note),
+    })
+    log.success(`Saved ${account.key} balance snapshot for ${date}: ${formatAmountWithCurrency(amount, currency)}`)
+  } catch (error) {
+    log.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  } finally {
+    database?.close()
+  }
+}
+
+export function createSnapshotAccountsCommand(defaultDb: string): Command {
+  return new Command('snapshot')
+    .description('Save an account balance snapshot')
+    .argument('<key>', 'account key')
+    .argument('<amount>', 'account balance amount')
+    .option('--date <YYYY-MM-DD>', 'snapshot date (defaults to today)')
+    .option('--currency <code>', '3-letter currency code', 'EUR')
+    .option('--note <text>', 'optional snapshot note')
+    .option('--db <path>', 'SQLite database path', defaultDb)
+    .action(snapshotAccountAction)
+}

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -37,7 +37,19 @@ erDiagram
         string imported_at
     }
 
+    ACCOUNT_BALANCE_SNAPSHOTS {
+        int id PK
+        int account_id FK
+        string date
+        float amount
+        string currency
+        string note
+        string created_at
+        string updated_at
+    }
+
     ACCOUNTS ||--o{ TRANSACTIONS : account_id
+    ACCOUNTS ||--o{ ACCOUNT_BALANCE_SNAPSHOTS : account_id
     CATEGORIES ||--o{ CATEGORIES : parent_of
     CATEGORIES ||--o{ TRANSACTIONS : category_id
 ```

--- a/src/db/account_balance_snapshots/README.md
+++ b/src/db/account_balance_snapshots/README.md
@@ -1,0 +1,26 @@
+# Account Balance Snapshots
+
+Stores authoritative end-of-day balances for configured accounts.
+
+## Table
+
+- `account_balance_snapshots`
+- One row per `(account_id, date)`
+- `amount` can be negative to support overdrafts
+- `currency` defaults to `EUR`
+- `note` is optional user context
+
+## Queries
+
+- `getBalanceSnapshotForDate` returns an exact snapshot.
+- `getLatestBalanceSnapshotOnOrBefore` returns the closest prior snapshot for forward derivation.
+- `getEarliestBalanceSnapshotOnOrAfter` returns the closest future snapshot for reverse derivation.
+- `getBalanceSnapshots` lists snapshots by optional account and date filters.
+
+## Mutations
+
+- `upsertAccountBalanceSnapshot` inserts a snapshot or updates the existing snapshot for the same account and date.
+
+## Derivation rule
+
+Snapshots are authoritative. Point-in-time balances and balance history are derived by applying same-account transactions around the closest snapshot. Transactions without `account_id` are not included in account balances.

--- a/src/db/account_balance_snapshots/date.ts
+++ b/src/db/account_balance_snapshots/date.ts
@@ -1,0 +1,33 @@
+const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+export function currentCalendarDate(): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function isCalendarDate(value: string): boolean {
+  if (!CALENDAR_DATE_PATTERN.test(value)) return false
+
+  const parsedDate = new Date(`${value}T00:00:00.000Z`)
+  return parsedDate.toISOString().slice(0, 10) === value
+}
+
+export function requireCalendarDate(value: string, fieldName: string): string {
+  const trimmedValue = value.trim()
+  if (isCalendarDate(trimmedValue)) return trimmedValue
+  throw new Error(`Invalid ${fieldName}: "${value}". Use YYYY-MM-DD.`)
+}
+
+export function requireDateRange(from: string, to: string): void {
+  if (from <= to) return
+  throw new Error(`Invalid date range: --from ${from} is after --to ${to}.`)
+}
+
+export function nextCalendarDate(value: string): string {
+  const parsedDate = new Date(`${value}T00:00:00.000Z`)
+  parsedDate.setUTCDate(parsedDate.getUTCDate() + 1)
+  return parsedDate.toISOString().slice(0, 10)
+}

--- a/src/db/account_balance_snapshots/derived.test.ts
+++ b/src/db/account_balance_snapshots/derived.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { insertAccount } from '@/db/accounts/mutations'
+import { createAccountsTable } from '@/db/accounts/schema'
+import { insertTransaction } from '@/db/transactions/mutations'
+import { createTransactionsTable } from '@/db/transactions/schema'
+import { upsertAccountBalanceSnapshot } from './mutations'
+import { getBalanceHistory, getDerivedAccountBalance } from './derived'
+import { createAccountBalanceSnapshotsTable } from './schema'
+
+let database: Database
+let accountId: number
+let otherAccountId: number
+
+beforeEach(() => {
+  database = new Database(':memory:')
+  createAccountsTable(database)
+  createAccountBalanceSnapshotsTable(database)
+  createTransactionsTable(database)
+  accountId = insertAccount(database, {
+    key: 'checking',
+    company: 'Provider One',
+    name: 'Main account',
+  })
+  otherAccountId = insertAccount(database, {
+    key: 'savings',
+    company: 'Provider One',
+    name: 'Savings account',
+  })
+})
+
+function addTransaction(date: string, amount: number, targetAccountId = accountId): void {
+  insertTransaction(database, {
+    date,
+    amount,
+    counterparty: 'ACME Shop',
+    currency: 'EUR',
+    accountId: targetAccountId,
+    importedAt: '2026-06-04T00:00:00.000Z',
+  })
+}
+
+describe('getDerivedAccountBalance', () => {
+  it('returns exact snapshot balance on the snapshot date', () => {
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-01',
+      amount: 1000,
+      currency: 'EUR',
+    })
+    addTransaction('2026-06-01', -50)
+
+    const balance = getDerivedAccountBalance(database, accountId, '2026-06-01')
+
+    expect(balance).toMatchObject({
+      accountId,
+      date: '2026-06-01',
+      amount: 1000,
+      snapshotDate: '2026-06-01',
+      direction: 'exact',
+    })
+  })
+
+  it('derives forward from a prior snapshot', () => {
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-01',
+      amount: 1000,
+      currency: 'EUR',
+    })
+    addTransaction('2026-06-02', -25)
+    addTransaction('2026-06-03', 100)
+
+    const balance = getDerivedAccountBalance(database, accountId, '2026-06-03')
+
+    expect(balance).toMatchObject({
+      amount: 1075,
+      snapshotDate: '2026-06-01',
+      direction: 'forward',
+    })
+  })
+
+  it('derives reverse from a future snapshot', () => {
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-10',
+      amount: 1000,
+      currency: 'EUR',
+    })
+    addTransaction('2026-06-09', -50)
+    addTransaction('2026-06-10', 20)
+
+    const balance = getDerivedAccountBalance(database, accountId, '2026-06-08')
+
+    expect(balance).toMatchObject({
+      amount: 1030,
+      snapshotDate: '2026-06-10',
+      direction: 'reverse',
+    })
+  })
+
+  it('ignores transactions from other accounts and unassigned transactions', () => {
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-01',
+      amount: 1000,
+      currency: 'EUR',
+    })
+    addTransaction('2026-06-02', -25)
+    addTransaction('2026-06-02', -200, otherAccountId)
+    insertTransaction(database, {
+      date: '2026-06-02',
+      amount: -300,
+      counterparty: 'Unassigned Merchant',
+      currency: 'EUR',
+      importedAt: '2026-06-04T00:00:00.000Z',
+    })
+
+    const balance = getDerivedAccountBalance(database, accountId, '2026-06-02')
+
+    expect(balance.amount).toBe(975)
+  })
+
+  it('throws when the account has no snapshots', () => {
+    expect(() => getDerivedAccountBalance(database, accountId, '2026-06-04')).toThrow(
+      'No balance snapshot found for account',
+    )
+  })
+})
+
+describe('getBalanceHistory', () => {
+  it('returns daily points for the inclusive range', () => {
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-01',
+      amount: 1000,
+      currency: 'EUR',
+    })
+    addTransaction('2026-06-02', -25)
+
+    const history = getBalanceHistory(database, {
+      accountId,
+      from: '2026-06-01',
+      to: '2026-06-03',
+    })
+
+    expect(history.map((point) => ({ date: point.date, amount: point.amount }))).toEqual([
+      { date: '2026-06-01', amount: 1000 },
+      { date: '2026-06-02', amount: 975 },
+      { date: '2026-06-03', amount: 975 },
+    ])
+  })
+})

--- a/src/db/account_balance_snapshots/derived.ts
+++ b/src/db/account_balance_snapshots/derived.ts
@@ -1,0 +1,75 @@
+import { type Database } from 'bun:sqlite'
+import type { BalanceHistoryFilters, BalanceHistoryPoint, DerivedAccountBalance } from '@/types'
+import { sumTransactionsForAccountAfterDateThroughDate } from '@/db/transactions/queries'
+import {
+  getEarliestBalanceSnapshotOnOrAfter,
+  getLatestBalanceSnapshotOnOrBefore,
+} from '@/db/account_balance_snapshots/queries'
+import { nextCalendarDate, requireCalendarDate, requireDateRange } from './date'
+
+export function getDerivedAccountBalance(db: Database, accountId: number, date: string): DerivedAccountBalance {
+  const targetDate = requireCalendarDate(date, 'date')
+  const latestSnapshot = getLatestBalanceSnapshotOnOrBefore(db, accountId, targetDate)
+
+  if (latestSnapshot !== undefined) {
+    return deriveFromPriorSnapshot(db, accountId, targetDate, latestSnapshot)
+  }
+
+  const futureSnapshot = getEarliestBalanceSnapshotOnOrAfter(db, accountId, targetDate)
+  if (futureSnapshot !== undefined) {
+    return deriveFromFutureSnapshot(db, accountId, targetDate, futureSnapshot)
+  }
+
+  throw new Error(`No balance snapshot found for account ${accountId}`)
+}
+
+export function getBalanceHistory(db: Database, filters: BalanceHistoryFilters): BalanceHistoryPoint[] {
+  const from = requireCalendarDate(filters.from, 'from date')
+  const to = requireCalendarDate(filters.to, 'to date')
+  requireDateRange(from, to)
+
+  const points: BalanceHistoryPoint[] = []
+  for (let date = from; date <= to; date = nextCalendarDate(date)) {
+    points.push(getDerivedAccountBalance(db, filters.accountId, date))
+  }
+
+  return points
+}
+
+function deriveFromPriorSnapshot(
+  db: Database,
+  accountId: number,
+  date: string,
+  snapshot: { amount: number; currency: string; date: string },
+): DerivedAccountBalance {
+  const transactionTotal = sumTransactionsForAccountAfterDateThroughDate(db, accountId, snapshot.date, date)
+  const direction = snapshot.date === date ? 'exact' : 'forward'
+  return toDerivedBalance(accountId, date, snapshot.amount + transactionTotal, snapshot, direction)
+}
+
+function deriveFromFutureSnapshot(
+  db: Database,
+  accountId: number,
+  date: string,
+  snapshot: { amount: number; currency: string; date: string },
+): DerivedAccountBalance {
+  const transactionTotal = sumTransactionsForAccountAfterDateThroughDate(db, accountId, date, snapshot.date)
+  return toDerivedBalance(accountId, date, snapshot.amount - transactionTotal, snapshot, 'reverse')
+}
+
+function toDerivedBalance(
+  accountId: number,
+  date: string,
+  amount: number,
+  snapshot: { currency: string; date: string },
+  direction: DerivedAccountBalance['direction'],
+): DerivedAccountBalance {
+  return {
+    accountId,
+    date,
+    amount,
+    currency: snapshot.currency,
+    snapshotDate: snapshot.date,
+    direction,
+  }
+}

--- a/src/db/account_balance_snapshots/mutations.test.ts
+++ b/src/db/account_balance_snapshots/mutations.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { insertAccount } from '@/db/accounts/mutations'
+import { createAccountsTable } from '@/db/accounts/schema'
+import { upsertAccountBalanceSnapshot } from './mutations'
+import { createAccountBalanceSnapshotsTable } from './schema'
+
+let database: Database
+let accountId: number
+
+beforeEach(() => {
+  database = new Database(':memory:')
+  createAccountsTable(database)
+  createAccountBalanceSnapshotsTable(database)
+  accountId = insertAccount(database, {
+    key: 'checking',
+    company: 'Provider One',
+    name: 'Main account',
+  })
+})
+
+describe('upsertAccountBalanceSnapshot', () => {
+  it('inserts a new snapshot row', () => {
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-04',
+      amount: 1250,
+      currency: 'EUR',
+      note: 'Statement balance',
+    })
+
+    const row = database.prepare('SELECT * FROM account_balance_snapshots').get() as Record<string, unknown>
+    expect(row).toMatchObject({
+      account_id: accountId,
+      date: '2026-06-04',
+      amount: 1250,
+      currency: 'EUR',
+      note: 'Statement balance',
+    })
+  })
+
+  it('updates amount, currency, and note for the same account and date', () => {
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-04',
+      amount: 1250,
+      currency: 'EUR',
+    })
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-04',
+      amount: 1300,
+      currency: 'USD',
+      note: 'Corrected',
+    })
+
+    const rows = database.prepare('SELECT * FROM account_balance_snapshots').all() as Record<string, unknown>[]
+    expect(rows).toMatchObject([
+      {
+        account_id: accountId,
+        date: '2026-06-04',
+        amount: 1300,
+        currency: 'USD',
+        note: 'Corrected',
+      },
+    ])
+  })
+
+  it('stores undefined note as null', () => {
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-04',
+      amount: 1250,
+      currency: 'EUR',
+    })
+
+    const row = database.prepare('SELECT note FROM account_balance_snapshots').get() as { note: string | null }
+    expect(row.note).toBeNull()
+  })
+})

--- a/src/db/account_balance_snapshots/mutations.ts
+++ b/src/db/account_balance_snapshots/mutations.ts
@@ -1,0 +1,26 @@
+import { type Database } from 'bun:sqlite'
+import type { NewAccountBalanceSnapshot } from '@/types'
+
+export function upsertAccountBalanceSnapshot(db: Database, snapshot: NewAccountBalanceSnapshot): void {
+  const timestamp = new Date().toISOString()
+
+  db.prepare(
+    `
+    INSERT INTO account_balance_snapshots (account_id, date, amount, currency, note, created_at, updated_at)
+    VALUES ($accountId, $date, $amount, $currency, $note, $createdAt, $updatedAt)
+    ON CONFLICT(account_id, date) DO UPDATE SET
+      amount = excluded.amount,
+      currency = excluded.currency,
+      note = excluded.note,
+      updated_at = excluded.updated_at
+  `,
+  ).run({
+    $accountId: snapshot.accountId,
+    $date: snapshot.date,
+    $amount: snapshot.amount,
+    $currency: snapshot.currency,
+    $note: snapshot.note ?? null,
+    $createdAt: timestamp,
+    $updatedAt: timestamp,
+  })
+}

--- a/src/db/account_balance_snapshots/queries.test.ts
+++ b/src/db/account_balance_snapshots/queries.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { insertAccount } from '@/db/accounts/mutations'
+import { createAccountsTable } from '@/db/accounts/schema'
+import { upsertAccountBalanceSnapshot } from './mutations'
+import {
+  getBalanceSnapshotForDate,
+  getBalanceSnapshots,
+  getEarliestBalanceSnapshotOnOrAfter,
+  getLatestBalanceSnapshotOnOrBefore,
+  hasBalanceSnapshotsForAccount,
+} from './queries'
+import { createAccountBalanceSnapshotsTable } from './schema'
+
+let database: Database
+let accountId: number
+let savingsAccountId: number
+
+beforeEach(() => {
+  database = new Database(':memory:')
+  createAccountsTable(database)
+  createAccountBalanceSnapshotsTable(database)
+  accountId = insertAccount(database, {
+    key: 'checking',
+    company: 'Provider One',
+    name: 'Main account',
+  })
+  savingsAccountId = insertAccount(database, {
+    key: 'savings',
+    company: 'Provider One',
+    name: 'Savings account',
+  })
+})
+
+describe('account balance snapshot queries', () => {
+  beforeEach(() => {
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-01',
+      amount: 1000,
+      currency: 'EUR',
+    })
+    upsertAccountBalanceSnapshot(database, {
+      accountId,
+      date: '2026-06-10',
+      amount: 1100,
+      currency: 'EUR',
+      note: 'Statement',
+    })
+    upsertAccountBalanceSnapshot(database, {
+      accountId: savingsAccountId,
+      date: '2026-06-05',
+      amount: 5000,
+      currency: 'EUR',
+    })
+  })
+
+  it('returns an exact snapshot for account and date', () => {
+    const snapshot = getBalanceSnapshotForDate(database, accountId, '2026-06-10')
+
+    expect(snapshot).toMatchObject({
+      accountId,
+      date: '2026-06-10',
+      amount: 1100,
+      note: 'Statement',
+    })
+  })
+
+  it('returns undefined when exact snapshot is missing', () => {
+    const snapshot = getBalanceSnapshotForDate(database, accountId, '2026-06-09')
+
+    expect(snapshot).toBeUndefined()
+  })
+
+  it('returns the latest snapshot on or before the date', () => {
+    const snapshot = getLatestBalanceSnapshotOnOrBefore(database, accountId, '2026-06-09')
+
+    expect(snapshot?.date).toBe('2026-06-01')
+  })
+
+  it('returns the earliest snapshot on or after the date', () => {
+    const snapshot = getEarliestBalanceSnapshotOnOrAfter(database, accountId, '2026-06-02')
+
+    expect(snapshot?.date).toBe('2026-06-10')
+  })
+
+  it('lists snapshots with account and date filters', () => {
+    const snapshots = getBalanceSnapshots(database, {
+      accountId,
+      from: '2026-06-02',
+      to: '2026-06-30',
+    })
+
+    expect(snapshots.map((snapshot) => snapshot.date)).toEqual(['2026-06-10'])
+  })
+
+  it('detects whether an account has balance snapshots', () => {
+    expect({
+      checking: hasBalanceSnapshotsForAccount(database, accountId),
+      missing: hasBalanceSnapshotsForAccount(database, 999),
+    }).toEqual({
+      checking: true,
+      missing: false,
+    })
+  })
+})

--- a/src/db/account_balance_snapshots/queries.ts
+++ b/src/db/account_balance_snapshots/queries.ts
@@ -1,0 +1,108 @@
+import { type Database, type SQLQueryBindings } from 'bun:sqlite'
+import type { AccountBalanceSnapshot, BalanceSnapshotFilters } from '@/types'
+
+type AccountBalanceSnapshotRow = {
+  id: number
+  account_id: number
+  date: string
+  amount: number
+  currency: string
+  note: string | null
+  created_at: string
+  updated_at: string
+}
+
+type SnapshotQueryParts = {
+  whereClause: string
+  params: SQLQueryBindings[]
+}
+
+function rowToAccountBalanceSnapshot(row: AccountBalanceSnapshotRow): AccountBalanceSnapshot {
+  return {
+    id: row.id,
+    accountId: row.account_id,
+    date: row.date,
+    amount: row.amount,
+    currency: row.currency,
+    note: row.note ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function buildSnapshotQueryParts(filters: BalanceSnapshotFilters): SnapshotQueryParts {
+  const conditions: string[] = []
+  const params: SQLQueryBindings[] = []
+
+  if (filters.accountId !== undefined) {
+    conditions.push('account_id = ?')
+    params.push(filters.accountId)
+  }
+  if (filters.from !== undefined) {
+    conditions.push('date >= ?')
+    params.push(filters.from)
+  }
+  if (filters.to !== undefined) {
+    conditions.push('date <= ?')
+    params.push(filters.to)
+  }
+
+  return {
+    whereClause: conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '',
+    params,
+  }
+}
+
+export function getBalanceSnapshotForDate(
+  db: Database,
+  accountId: number,
+  date: string,
+): AccountBalanceSnapshot | undefined {
+  const row = db
+    .prepare('SELECT * FROM account_balance_snapshots WHERE account_id = ? AND date = ?')
+    .get(accountId, date) as AccountBalanceSnapshotRow | null
+
+  if (row === null) return undefined
+  return rowToAccountBalanceSnapshot(row)
+}
+
+export function getLatestBalanceSnapshotOnOrBefore(
+  db: Database,
+  accountId: number,
+  date: string,
+): AccountBalanceSnapshot | undefined {
+  const row = db
+    .prepare('SELECT * FROM account_balance_snapshots WHERE account_id = ? AND date <= ? ORDER BY date DESC LIMIT 1')
+    .get(accountId, date) as AccountBalanceSnapshotRow | null
+
+  if (row === null) return undefined
+  return rowToAccountBalanceSnapshot(row)
+}
+
+export function getEarliestBalanceSnapshotOnOrAfter(
+  db: Database,
+  accountId: number,
+  date: string,
+): AccountBalanceSnapshot | undefined {
+  const row = db
+    .prepare('SELECT * FROM account_balance_snapshots WHERE account_id = ? AND date >= ? ORDER BY date ASC LIMIT 1')
+    .get(accountId, date) as AccountBalanceSnapshotRow | null
+
+  if (row === null) return undefined
+  return rowToAccountBalanceSnapshot(row)
+}
+
+export function getBalanceSnapshots(db: Database, filters: BalanceSnapshotFilters = {}): AccountBalanceSnapshot[] {
+  const { whereClause, params } = buildSnapshotQueryParts(filters)
+  const sql = `SELECT * FROM account_balance_snapshots ${whereClause} ORDER BY account_id ASC, date ASC`.trim()
+  const rows = db.prepare(sql).all(...params) as AccountBalanceSnapshotRow[]
+  return rows.map(rowToAccountBalanceSnapshot)
+}
+
+export function hasBalanceSnapshotsForAccount(db: Database, accountId: number): boolean {
+  const row = db
+    .prepare('SELECT 1 AS found FROM account_balance_snapshots WHERE account_id = ? LIMIT 1')
+    .get(accountId) as { found: number } | null
+
+  return row !== null
+}

--- a/src/db/account_balance_snapshots/schema.test.ts
+++ b/src/db/account_balance_snapshots/schema.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { insertAccount } from '@/db/accounts/mutations'
+import { createAccountsTable } from '@/db/accounts/schema'
+import { createAccountBalanceSnapshotsTable } from './schema'
+
+function createDatabase(): Database {
+  const database = new Database(':memory:')
+  database.run('PRAGMA foreign_keys = ON')
+  createAccountsTable(database)
+  createAccountBalanceSnapshotsTable(database)
+  return database
+}
+
+function getColumnNames(database: Database): string[] {
+  const rows = database.prepare("PRAGMA table_info('account_balance_snapshots')").all() as {
+    name: string
+  }[]
+  return rows.map((row) => row.name)
+}
+
+describe('createAccountBalanceSnapshotsTable', () => {
+  it('creates account balance snapshots table', () => {
+    const database = createDatabase()
+
+    const row = database
+      .query<{ name: string }, []>(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='account_balance_snapshots'",
+      )
+      .get()
+
+    expect(row?.name).toBe('account_balance_snapshots')
+  })
+
+  it('is idempotent', () => {
+    const database = createDatabase()
+
+    expect(() => createAccountBalanceSnapshotsTable(database)).not.toThrow()
+  })
+
+  it('creates all expected columns', () => {
+    const database = createDatabase()
+
+    expect(getColumnNames(database)).toEqual([
+      'id',
+      'account_id',
+      'date',
+      'amount',
+      'currency',
+      'note',
+      'created_at',
+      'updated_at',
+    ])
+  })
+
+  it('creates an account date index', () => {
+    const database = createDatabase()
+
+    const row = database
+      .query<{ name: string }, []>(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_account_balance_snapshots_account_date'",
+      )
+      .get()
+
+    expect(row?.name).toBe('idx_account_balance_snapshots_account_date')
+  })
+
+  it('rejects duplicate snapshots for the same account and date', () => {
+    const database = createDatabase()
+    const accountId = insertAccount(database, {
+      key: 'checking',
+      company: 'Provider One',
+      name: 'Main account',
+    })
+
+    database
+      .prepare(
+        `
+        INSERT INTO account_balance_snapshots (account_id, date, amount, currency, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run(accountId, '2026-06-04', 1000, 'EUR', '2026-06-04T00:00:00.000Z', '2026-06-04T00:00:00.000Z')
+
+    expect(() =>
+      database
+        .prepare(
+          `
+          INSERT INTO account_balance_snapshots (account_id, date, amount, currency, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+        `,
+        )
+        .run(accountId, '2026-06-04', 1100, 'EUR', '2026-06-04T00:00:00.000Z', '2026-06-04T00:00:00.000Z'),
+    ).toThrow()
+  })
+
+  it('enforces account foreign keys', () => {
+    const database = createDatabase()
+
+    expect(() =>
+      database
+        .prepare(
+          `
+          INSERT INTO account_balance_snapshots (account_id, date, amount, currency, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+        `,
+        )
+        .run(999, '2026-06-04', 1000, 'EUR', '2026-06-04T00:00:00.000Z', '2026-06-04T00:00:00.000Z'),
+    ).toThrow()
+  })
+
+  it('allows negative balances for overdrafts', () => {
+    const database = createDatabase()
+    const accountId = insertAccount(database, {
+      key: 'checking',
+      company: 'Provider One',
+      name: 'Main account',
+    })
+
+    database
+      .prepare(
+        `
+        INSERT INTO account_balance_snapshots (account_id, date, amount, currency, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run(accountId, '2026-06-04', -100, 'EUR', '2026-06-04T00:00:00.000Z', '2026-06-04T00:00:00.000Z')
+
+    const row = database.prepare('SELECT amount FROM account_balance_snapshots').get() as { amount: number }
+    expect(row.amount).toBe(-100)
+  })
+})

--- a/src/db/account_balance_snapshots/schema.ts
+++ b/src/db/account_balance_snapshots/schema.ts
@@ -1,0 +1,26 @@
+import { type Database } from 'bun:sqlite'
+
+const ACCOUNT_DATE_INDEX = 'idx_account_balance_snapshots_account_date'
+
+export function createAccountBalanceSnapshotsTable(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS account_balance_snapshots (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      account_id  INTEGER NOT NULL REFERENCES accounts(id) ON DELETE RESTRICT,
+      date        TEXT NOT NULL,
+      amount      REAL NOT NULL,
+      currency    TEXT NOT NULL DEFAULT 'EUR' CHECK(length(currency) > 0),
+      note        TEXT,
+      created_at  TEXT NOT NULL,
+      updated_at  TEXT NOT NULL,
+      UNIQUE(account_id, date),
+      CHECK(length(date) = 10)
+    )
+  `)
+
+  createAccountDateIndex(db)
+}
+
+function createAccountDateIndex(db: Database): void {
+  db.run(`CREATE INDEX IF NOT EXISTS ${ACCOUNT_DATE_INDEX} ON account_balance_snapshots (account_id, date)`)
+}

--- a/src/db/schema.test.ts
+++ b/src/db/schema.test.ts
@@ -42,6 +42,15 @@ describe('initDb', () => {
     expect(row?.name).toBe('monthly_income_snapshots')
   })
 
+  it('creates account_balance_snapshots table', () => {
+    const db = new Database(':memory:')
+    initDb(db)
+    const row = db
+      .query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type='table' AND name='account_balance_snapshots'")
+      .get()
+    expect(row?.name).toBe('account_balance_snapshots')
+  })
+
   it('is idempotent (safe to call twice)', () => {
     const db = new Database(':memory:')
     expect(() => {
@@ -61,6 +70,7 @@ describe('openDatabase', () => {
     expect(tables).toContain('categories')
     expect(tables).toContain('transactions')
     expect(tables).toContain('accounts')
+    expect(tables).toContain('account_balance_snapshots')
     expect(tables).toContain('budgets')
     expect(tables).toContain('monthly_income_snapshots')
     db.close()

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,5 @@
 import { Database } from 'bun:sqlite'
+import { createAccountBalanceSnapshotsTable } from '@/db/account_balance_snapshots/schema'
 import { createAccountsTable } from '@/db/accounts/schema'
 import { createBudgetsTable, createMonthlyIncomeSnapshotsTable } from '@/db/budgets/schema'
 import { createCategoriesTable } from '@/db/categories/schema'
@@ -20,6 +21,7 @@ export function initDb(db: Database): void {
   db.run('PRAGMA foreign_keys = ON')
   createCategoriesTable(db)
   createAccountsTable(db)
+  createAccountBalanceSnapshotsTable(db)
   createTransactionsTable(db)
   createTransactionCategorySuggestionsTable(db)
   migrateTransactionCategorySuggestionsTable(db)

--- a/src/db/transactions/queries.test.ts
+++ b/src/db/transactions/queries.test.ts
@@ -17,6 +17,7 @@ import {
   getTransactionsEligibleForCategorization,
   getUncategorized,
   hasTransactionsForAccount,
+  sumTransactionsForAccountAfterDateThroughDate,
 } from './queries'
 
 const fakeTransaction: NewTransaction = {
@@ -157,6 +158,30 @@ describe('hasTransactionsForAccount', () => {
       key: 'checking',
       company: 'Belfius',
       name: 'Main account',
+    })
+
+    describe('sumTransactionsForAccountAfterDateThroughDate', () => {
+      it('sums signed transactions for one account in an exclusive-inclusive date range', () => {
+        const accountId = insertAccount(db, {
+          key: 'checking',
+          company: 'Belfius',
+          name: 'Main account',
+        })
+        const otherAccountId = insertAccount(db, {
+          key: 'savings',
+          company: 'Belfius',
+          name: 'Savings account',
+        })
+
+        insertTransaction(db, { ...fakeTransaction, date: '2026-06-01', amount: -100, accountId })
+        insertTransaction(db, { ...fakeTransaction, date: '2026-06-02', amount: -25, accountId })
+        insertTransaction(db, { ...fakeTransaction, date: '2026-06-03', amount: 50, accountId })
+        insertTransaction(db, { ...fakeTransaction, date: '2026-06-03', amount: -500, accountId: otherAccountId })
+
+        const total = sumTransactionsForAccountAfterDateThroughDate(db, accountId, '2026-06-01', '2026-06-03')
+
+        expect(total).toBe(25)
+      })
     })
 
     expect(hasTransactionsForAccount(db, accountId)).toBe(false)

--- a/src/db/transactions/queries.ts
+++ b/src/db/transactions/queries.ts
@@ -117,6 +117,27 @@ export function hasTransactionsForAccount(db: Database, accountId: number): bool
   return row !== null
 }
 
+export function sumTransactionsForAccountAfterDateThroughDate(
+  db: Database,
+  accountId: number,
+  afterDate: string,
+  throughDate: string,
+): number {
+  const row = db
+    .prepare(
+      `
+      SELECT COALESCE(SUM(amount), 0) AS total
+      FROM transactions
+      WHERE account_id = ?
+        AND date > ?
+        AND date <= ?
+    `,
+    )
+    .get(accountId, afterDate, throughDate) as { total: number }
+
+  return row.total
+}
+
 export function getTransactionsEligibleForCategorization(
   db: Database,
   filters: CategorizeTransactionsFilters = {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,3 +124,41 @@ export interface Budget {
 }
 
 export type NewBudget = Omit<Budget, 'id'>
+
+export type AccountBalanceSnapshot = {
+  id: number
+  accountId: number
+  date: string
+  amount: number
+  currency: string
+  note?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type NewAccountBalanceSnapshot = Omit<AccountBalanceSnapshot, 'id' | 'createdAt' | 'updatedAt'>
+
+export type BalanceSnapshotFilters = {
+  accountId?: number
+  from?: string
+  to?: string
+}
+
+export type BalanceDerivationDirection = 'exact' | 'forward' | 'reverse'
+
+export type DerivedAccountBalance = {
+  accountId: number
+  date: string
+  amount: number
+  currency: string
+  snapshotDate: string
+  direction: BalanceDerivationDirection
+}
+
+export type BalanceHistoryFilters = {
+  accountId: number
+  from: string
+  to: string
+}
+
+export type BalanceHistoryPoint = DerivedAccountBalance


### PR DESCRIPTION
Adds account balance tracking so flouz can store authoritative per-account balance snapshots and derive point-in-time balances or daily history from imported transactions.

## Summary

- Adds an `account_balance_snapshots` table with typed schema, queries, upsert mutation, and derivation helpers.
- Adds `flouz accounts snapshot`, `flouz accounts balance`, and `flouz accounts history` commands.
- Derives balances from the nearest snapshot plus same-account transactions, while ignoring unassigned transactions.
- Prevents deleting accounts that still have balance snapshots.
- Updates database/account docs and adds focused DB and command tests.

## Validation

- `git diff --check` passed.
- `bun test`, typecheck, lint, and format checks were not run because `bun` is not available on PATH in this environment.